### PR TITLE
Validate routine type signatures

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,6 +13,7 @@ import IR.Lowering  ( astToIR )
 --import CGen ( cgen, hgen )
 
 import qualified Ast as A
+import Passes ( checkRoutineSignatures )
 
 import System.Environment (getArgs, getProgName)
 import System.Console.GetOpt (getOpt, usageInfo, OptDescr(..),
@@ -99,7 +100,7 @@ main = do
                    filename -> readFile filename) filenames
                               
   ast <- case runAlex (head inputs) parse of -- FIXME: multiple inputs?
-           Right a -> return a
+           Right a -> return $ checkRoutineSignatures a
            Left s -> do hPutStrLn stderr $ "Error: " ++ s
                         exitFailure
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -100,9 +100,12 @@ main = do
                    filename -> readFile filename) filenames
                               
   ast <- case runAlex (head inputs) parse of -- FIXME: multiple inputs?
-           Right a -> return $ checkRoutineSignatures a
+           Right a -> return a
            Left s -> do hPutStrLn stderr $ "Error: " ++ s
                         exitFailure
+
+  when (not $ checkRoutineSignatures ast) $ (do hPutStrLn stderr "Error: type signature mismatch"
+                                                exitFailure)
 
   when (optMode == DumpAST) $ print ast >> exitSuccess
 

--- a/src/Passes.hs
+++ b/src/Passes.hs
@@ -2,16 +2,13 @@ module Passes where
 
 import qualified Ast as A
 
-checkRoutineSignatures :: A.Program -> A.Program
-checkRoutineSignatures (A.Program decls) = A.Program $ map checkAnnotations decls
+checkRoutineSignatures :: A.Program -> Bool 
+checkRoutineSignatures (A.Program decls) = and $ map checkAnnotations decls
   where
-    checkAnnotations decl@(A.Function _ binds _ fnTyAnn) =
+    checkAnnotations (A.Function _ binds _ fnTyAnn) =
         case fnTyAnn of 
-          A.ReturnType _ -> let res = foldl annotatedOnce True binds in
-                                if res then decl else error "bad"
-          A.CurriedType ty -> let numParams = countParams ty
-                                  noneAnnotated = foldl notAnnotated True binds in
-                                  if numParams == length binds && noneAnnotated then decl else error "bad"
+          A.ReturnType _ -> foldl annotatedOnce True binds
+          A.CurriedType ty -> countParams ty == length binds && foldl notAnnotated True binds
 
     annotatedOnce ret (A.Bind _ (Just _)) = ret && True
     annotatedOnce ret (A.TupBind bds tupTy) = ret && case tupTy of

--- a/src/Passes.hs
+++ b/src/Passes.hs
@@ -9,7 +9,9 @@ checkRoutineSignatures (A.Program decls) = A.Program $ map checkAnnotations decl
         case fnTyAnn of 
           A.ReturnType _ -> let res = foldl annotatedOnce True binds in
                                 if res then decl else error "bad"
-          A.CurriedType _ -> decl --{- get arrow length, check same. -} foldl notAnnotated True binds
+          A.CurriedType ty -> let numParams = countParams ty
+                                  noneAnnotated = foldl notAnnotated True binds in
+                                  if numParams == length binds && noneAnnotated then decl else error "bad"
 
     annotatedOnce ret (A.Bind _ (Just _)) = ret && True
     annotatedOnce ret (A.TupBind bds tupTy) = ret && case tupTy of
@@ -20,4 +22,7 @@ checkRoutineSignatures (A.Program decls) = A.Program $ map checkAnnotations decl
     notAnnotated ret (A.Bind _ Nothing) = ret && True
     notAnnotated ret (A.TupBind bds Nothing) = ret && foldl notAnnotated True bds
     notAnnotated _ _ = False
+
+    countParams (A.TArrow _ t2) = 1 + countParams t2
+    countParams _ = 0
 

--- a/src/Passes.hs
+++ b/src/Passes.hs
@@ -1,0 +1,23 @@
+module Passes where
+
+import qualified Ast as A
+
+checkRoutineSignatures :: A.Program -> A.Program
+checkRoutineSignatures (A.Program decls) = A.Program $ map checkAnnotations decls
+  where
+    checkAnnotations decl@(A.Function _ binds _ fnTyAnn) =
+        case fnTyAnn of 
+          A.ReturnType _ -> let res = foldl annotatedOnce True binds in
+                                if res then decl else error "bad"
+          A.CurriedType _ -> decl --{- get arrow length, check same. -} foldl notAnnotated True binds
+
+    annotatedOnce ret (A.Bind _ (Just _)) = ret && True
+    annotatedOnce ret (A.TupBind bds tupTy) = ret && case tupTy of
+                                                     Just _ -> foldl notAnnotated True bds
+                                                     Nothing -> foldl annotatedOnce True bds
+    annotatedOnce _ _ = False
+
+    notAnnotated ret (A.Bind _ Nothing) = ret && True
+    notAnnotated ret (A.TupBind bds Nothing) = ret && foldl notAnnotated True bds
+    notAnnotated _ _ = False
+

--- a/src/Passes.hs
+++ b/src/Passes.hs
@@ -3,23 +3,22 @@ module Passes where
 import qualified Ast as A
 
 checkRoutineSignatures :: A.Program -> Bool 
-checkRoutineSignatures (A.Program decls) = and $ map checkAnnotations decls
+checkRoutineSignatures (A.Program decls) = all checkAnnotations decls
   where
     checkAnnotations (A.Function _ binds _ fnTyAnn) =
         case fnTyAnn of 
-          A.ReturnType _ -> foldl annotatedOnce True binds
-          A.CurriedType ty -> countParams ty == length binds && foldl notAnnotated True binds
-
-    annotatedOnce ret (A.Bind _ (Just _)) = ret && True
-    annotatedOnce ret (A.TupBind bds tupTy) = ret && case tupTy of
-                                                     Just _ -> foldl notAnnotated True bds
-                                                     Nothing -> foldl annotatedOnce True bds
-    annotatedOnce _ _ = False
-
-    notAnnotated ret (A.Bind _ Nothing) = ret && True
-    notAnnotated ret (A.TupBind bds Nothing) = ret && foldl notAnnotated True bds
-    notAnnotated _ _ = False
+          A.ReturnType _ -> all annotatedOnce binds
+          A.CurriedType ty -> countParams ty == length binds && all notAnnotated binds
 
     countParams (A.TArrow _ t2) = 1 + countParams t2
     countParams _ = 0
 
+    annotatedOnce (A.Bind _ (Just _)) = True
+    annotatedOnce (A.TupBind bds tupTy) = case tupTy of
+                                            Just _ -> all notAnnotated bds
+                                            Nothing -> all annotatedOnce bds
+    annotatedOnce _ = False
+
+    notAnnotated (A.Bind _ Nothing) = True
+    notAnnotated (A.TupBind bds Nothing) = all notAnnotated bds
+    notAnnotated _ = False


### PR DESCRIPTION
That is,
- Assert all args are annotated exactly once for Pythonic signatures
- Assert all args are not annotated and that the annotated arrow type is consistent with the number of args for Haskell-like signatures