### PR TITLE
Lower AST to IR

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,7 +9,7 @@ import Front.Parser  ( parse )
 import Front.ParseOperators ( parseOperators, Fixity(..) )
 
 --import Ast ( printAST )
-import IR.Lowering  ( lowerProgram )
+import Front.Lowering  ( lowerProgram )
 --import CGen ( cgen, hgen )
 
 import qualified Front.Ast as A
@@ -104,8 +104,9 @@ main = do
            Left s -> do hPutStrLn stderr $ "Error: " ++ s
                         exitFailure
 
-  when (not $ checkRoutineSignatures ast) $ do hPutStrLn stderr "Error: type signature mismatch"
-                                               exitFailure
+  when (not $ checkRoutineSignatures ast) $ do
+    hPutStrLn stderr "Error: type signature mismatch"
+    exitFailure
 
   when (optMode == DumpAST) $ print ast >> exitSuccess
 
@@ -116,7 +117,7 @@ main = do
 
   when (optMode == DumpASTP) $ print ast' >> exitSuccess
 
-  let ir = lowerProgram ast'
+  let _ = lowerProgram ast'
 
   -- FIXME: Pretty printers for the various IRs (mostly types)
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,7 +9,7 @@ import Front.Parser  ( parse )
 import Front.ParseOperators ( parseOperators, Fixity(..) )
 
 --import Ast ( printAST )
-import IR.Lowering  ( astToIR )
+import IR.Lowering  ( lowerProgram )
 --import CGen ( cgen, hgen )
 
 import qualified Front.Ast as A
@@ -116,7 +116,7 @@ main = do
 
   when (optMode == DumpASTP) $ print ast' >> exitSuccess
 
-  let ir = astToIR ast'
+  let ir = lowerProgram ast'
 
   -- FIXME: Pretty printers for the various IRs (mostly types)
 

--- a/package.yaml
+++ b/package.yaml
@@ -32,6 +32,7 @@ library:
   - containers
   - language-c-quote
   - srcloc
+  - composition
 
 executables:
   sslc:

--- a/src/Codegen/Codegen.hs
+++ b/src/Codegen/Codegen.hs
@@ -246,7 +246,7 @@ genTop (name, l@(L.Lambda _ _ ty)) =
     return ([structDefn, enterDecl, stepDecl], [enterDefn, stepDefn])
  where
   (argIds, body ) = L.collectLambda l
-  (argTys, retTy) = L.dearrow ty
+  (argTys, retTy) = L.collectArrow ty
 genTop (_, L.Lit _ _) = todo
 genTop (_, _        ) = nope
 

--- a/src/Common/Identifiers.hs
+++ b/src/Common/Identifiers.hs
@@ -4,7 +4,20 @@
 These are defined as newtypes (rather than as type aliases) so that they cannot
 be accidentally compared with one another.
 -}
-module Common.Identifiers where
+module Common.Identifiers
+  ( Identifiable(..)
+  , IsString(..)
+  , fromId
+  , TVarId(..)
+  , TConId(..)
+  , DConId(..)
+  , TVarIdx(..)
+  , FfiId(..)
+  , VarId(..)
+  , FieldId(..)
+  , Binder
+  , Identifier(..)
+  ) where
 
 import           Data.String                    ( IsString(..) )
 
@@ -34,7 +47,7 @@ instance Semigroup Identifier where
 instance Monoid Identifier where
   mempty = Identifier ""
 
-fromId :: (Identifiable a , Identifiable b) => a -> b
+fromId :: (Identifiable a, Identifiable b) => a -> b
 fromId = fromString . ident
 
 -- | ToIdentifier for type variable, e.g., "a".

--- a/src/Front/Lowering.hs
+++ b/src/Front/Lowering.hs
@@ -1,4 +1,4 @@
-module IR.Lowering
+module Front.Lowering
   ( lowerProgram
   ) where
 

--- a/src/Front/Parser.y
+++ b/src/Front/Parser.y
@@ -112,14 +112,14 @@ typ2 : id                        { TCon $1 }
 tupleTyps : typ               { [$1] }
           | typ ',' tupleTyps { $1 : $3 }
 
-expr : expr ';' expr0 { Seq $1 $3 }
-     | expr0          { $1 }
+expr : expr ';' expr0                   { Seq $1 $3 }
+     | 'let' '{' decls '}' ';' expr     { Let (reverse $3) $6 }
+     | expr0                            { $1 }
 
 expr0 : 'if' expr 'then' expr0 elseOpt  { IfElse $2 $4 $5 }
       | 'while' expr 'do' expr0         { While $2 $4 }
-      | 'let' '{' decls '}'             { Let (reverse $3) }
       | 'loop' expr0                    { Loop $2 }
-      | 'wait' ids                      { Wait $2 }
+      | 'wait' '{' parExprs '}'         { Wait $3 }
       | 'par' '{' parExprs '}'          { Par (reverse $3) }
       | expr2 'later' expr2 '<-' expr0  { Later $1 (exprToPat $3) $5 }
       | expr2 '<-' expr0                { Assign (exprToPat $1) $3 }

--- a/src/IR/IR.hs
+++ b/src/IR/IR.hs
@@ -19,6 +19,7 @@ import           Common.Identifiers             ( Binder
                                                 , VarId(..)
                                                 )
 
+import           Data.Bifunctor                 ( Bifunctor(..) )
 import           Types.TypeSystem               ( TypeDef(..) )
 
 -- | Top-level compilation unit.
@@ -187,6 +188,20 @@ typeExpr (App    _ _ t ) = t
 typeExpr (Match _ _ _ t) = t
 typeExpr (Prim _ _ t   ) = t
 
+instance Functor Expr where
+  fmap f (Var  v t      ) = Var v (f t)
+  fmap f (Data d t      ) = Data d (f t)
+  fmap f (Lit  l t      ) = Lit l (f t)
+  fmap f (App    l  r t ) = App (fmap f l) (fmap f r) (f t)
+  fmap f (Let    xs b t ) = Let (fmap (second $ fmap f) xs) (fmap f b) (f t)
+  fmap f (Lambda v  b t ) = Lambda v (fmap f b) (f t)
+  fmap f (Match s b as t) = Match (fmap f s) b (fmap (fmap f) as) (f t)
+  fmap f (Prim p as t   ) = Prim p (fmap (fmap f) as) (f t)
+
+instance Functor Alt where
+  fmap f (AltData d bs b) = AltData d bs (fmap f b)
+  fmap f (AltLit l b    ) = AltLit l (fmap f b)
+  fmap f (AltDefault b  ) = AltDefault (fmap f b)
 
 {- | Predicate of whether an expression "looks about right".
 

--- a/src/IR/Lowering.hs
+++ b/src/IR/Lowering.hs
@@ -1,10 +1,143 @@
 module IR.Lowering
-  ( astToIR
+  ( lowerProgram
   ) where
 
 import qualified Front.Ast                     as A
 import qualified IR.IR                         as L
-import qualified Types.Ast                     as A
+import qualified Types.Ast                     as L
+import qualified Types.TypeSystem              as L
 
-astToIR :: A.Program -> L.Program A.Type
-astToIR (A.Program _) = error "TODO"
+import           Common.Identifiers             ( fromString )
+import           Data.Composition               ( (.:) )
+import           Data.Maybe                     ( fromJust )
+
+todo, nope, what :: a
+todo = error "TODO"
+nope = error "Not going to implement this"
+what = error "What does this even mean"
+
+-- | Lower an AST 'Program' into IR.
+lowerProgram :: A.Program -> L.Program L.Type
+lowerProgram (A.Program ds) = L.Program { L.programEntry = todo
+                                        , L.programDefs  = map lowerDecl ds
+                                        , L.typeDefs     = [todo]
+                                        }
+-- | Lower a top-level 'Declaration' into triple of name, type, and definition.
+lowerDecl :: A.Declaration -> (L.VarId, L.Expr L.Type)
+lowerDecl (A.Function aName aBinds aBody aTy) = (lName, lBody)
+ where
+  lName = fromString aName
+  lTy   = case aTy of
+    A.CurriedType t -> lowerType t
+    A.ReturnType  t -> foldr buildArrow (lowerType t) aBinds
+      -- Construct a curried arrow type while folding through a list of binds
+     where
+      buildArrow =
+        L.Type
+          .  (: [])
+          .  L.TBuiltin
+          .: L.Arrow
+          .  lowerType
+          .  fromJust
+          .  bindType
+  lBody = lowerBinds aBinds aBody lTy
+
+  -- | Extracts possible AST type annotation from a binding.
+  bindType :: A.Bind -> Maybe A.Ty
+  bindType (A.Bind    _    (Just ty)) = return ty
+  bindType (A.TupBind _    (Just ty)) = return ty
+  bindType (A.TupBind tups Nothing  ) = A.TTuple <$> mapM bindType tups
+  bindType _                          = Nothing
+
+  {- | Lowers function args and body into nested lambdas.
+
+  As this function unpacks the bindings, it also unpacks the outer function's
+  type annotation to appropriate annotate each sub-lambda.
+  -}
+  lowerBinds :: [A.Bind] -> A.Expr -> L.Type -> L.Expr L.Type
+  lowerBinds (A.Bind v _ : bs) body ty = L.Lambda
+    (Just $ fromString v)
+    (lowerBinds bs body (snd $ fromJust $ L.dearrow ty))
+    ty
+  lowerBinds (A.TupBind _b _ty : _bs) _body _  = todo -- Need to desugar this to match
+  lowerBinds []                       body  ty = lowerExpr body (<> ty)
+
+-- | Lowers the AST's representation of types into that of the IR.
+lowerType :: A.Ty -> L.Type
+lowerType (  A.TCon i  ) = L.Type [L.TCon (fromString i) []]
+lowerType a@(A.TApp _ _) = case A.collectTApp a of
+  (A.TCon i, args) -> L.Type [L.TCon (fromString i) $ map lowerType args]
+  _                -> nope
+lowerType (A.TTuple tys) = L.Type [L.TBuiltin $ L.Tuple $ map lowerType tys]
+lowerType (A.TArrow lhs rhs) =
+  L.Type [L.TBuiltin $ L.Arrow (lowerType lhs) (lowerType rhs)]
+
+-- | Lowers an AST expression into an IR expression. Performs desguaring inline.
+lowerExpr :: A.Expr -> (L.Type -> L.Type) -> L.Expr L.Type
+lowerExpr (A.Id      v) k = L.Var (fromString v) (k L.untyped)
+lowerExpr (A.Literal l) k = L.Lit (lowerLit l) (k L.untyped)
+lowerExpr (A.Apply l r) k = L.App lhs rhs (k L.untyped)
+  where (lhs, rhs) = (lowerExpr l id, lowerExpr r id)
+lowerExpr (A.Let ds b) k = L.Let defs body (k L.untyped)
+ where
+  (defs, body) = (map lowerLet ds, lowerExpr b id)
+  -- | Accumulator to lower an AST let-binding into an IR let-binding.
+  lowerLet (A.Def (A.PId n)       d ) = (Just $ fromString n, lowerExpr d id)
+  lowerLet (A.Def A.PWildcard     e ) = (Nothing, lowerExpr e id)
+  lowerLet (A.Def (A.PAs  _n _p ) _e) = todo
+    {- This is tricky because something like
+      @
+        let p'' = d''
+            n@p = d
+            p' = d'
+        in b
+      @
+
+      is desugared into
+
+      @
+        let p'' = let p = n in d''
+            n = d
+            p' = let p = n in d'
+        in let p = n in b
+      @
+
+      To account for the alias being used in co-recursive definitions as well as
+      the let-body. This desugaring should be done somewhere, but probably not
+      here.
+    -}
+  lowerLet (A.Def (A.PCon _n _ps) _ ) = what -- Why is n a TConId?
+  lowerLet (A.Def (A.PLiteral _l) _e) = what
+
+lowerExpr (A.While c b) k = L.Prim L.Loop [body] (k L.untyped)
+  where body = lowerExpr (A.IfElse c A.Break A.NoExpr `A.Seq` b) id
+lowerExpr (A.Loop b ) k = L.Prim L.Loop [lowerExpr b id] (k L.untyped)
+lowerExpr (A.Par  es) k = L.Prim L.Fork exprs (k L.untyped)
+  where exprs = map (`lowerExpr` id) es
+lowerExpr (A.IfElse c t e) k = L.Match cond Nothing [tArm, eArm] (k L.untyped)
+ where
+  cond = lowerExpr c id
+  tArm = L.AltLit (L.LitBool True) (lowerExpr t id)
+  eArm = L.AltDefault (lowerExpr e id)
+lowerExpr (A.Later delay lhs rhs) k = L.Prim L.After args (k L.untyped)
+  where args = map (`lowerExpr` id) [delay, todo lhs, rhs]
+lowerExpr (A.Assign lhs rhs) k = L.Prim L.Assign args (k L.untyped)
+  where args = map (`lowerExpr` id) [todo lhs, rhs]
+lowerExpr (A.Constraint e ty) k = lowerExpr e ((<> lowerType ty) . k)
+lowerExpr (A.Wait exprs     ) k = L.Prim L.Wait args (k L.untyped)
+  where args = map (`lowerExpr` id) exprs
+lowerExpr (A.Seq l r) k = L.Let [(Nothing, lhs)] rhs (k L.untyped)
+  where (lhs, rhs) = (lowerExpr l id, lowerExpr r id)
+lowerExpr A.Break          k = L.Prim L.Break [] (k L.untyped)
+lowerExpr (A.Return e    ) k = L.Prim L.Return [lowerExpr e id] (k L.untyped)
+lowerExpr (A.OpRegion _ _) _ = error "Should already be desugared"
+lowerExpr A.NoExpr         _ = what -- Perhaps this should be a unit literal?
+lowerExpr A.Wildcard       _ = what
+lowerExpr (A.As _ _)       _ = what
+
+-- | Lower an AST literal into an IR literal.
+lowerLit :: A.Lit -> L.Literal
+lowerLit (A.IntLit    i ) = L.LitIntegral i
+lowerLit (A.StringLit _s) = todo
+lowerLit (A.RatLit    _r) = todo
+lowerLit (A.CharLit   _c) = todo

--- a/src/Types/Ast.hs
+++ b/src/Types/Ast.hs
@@ -5,9 +5,48 @@ Types straight from the AST.
 For now, just the polymorphic typeclass types.
 
 -}
+{-# LANGUAGE DerivingVia #-}
+module Types.Ast
+  ( Builtin(..)
+  , Type(..)
+  , TypeAnnote(..)
+  , untyped) where
+import           Common.Identifiers             ( TConId
+                                                , TVarIdx
+                                                )
+import           Types.TypeSystem               ( Builtin(..)
+                                                , TypeSystem(..)
+                                                )
+{- | A single term may be annotated by zero or more types.
 
-module Types.Ast (
-  module Types
-  ) where
+When multiple exist, it should be assumed that they are "equivalent", in the
+sense that they can be unified.
 
-import Types.Classes as Types
+Type annotations can be added using '<>' (from 'Semigroup'), while 'mempty'
+represents no type annotation.
+-}
+newtype Type = Type [TypeAnnote]
+  deriving Eq         via [TypeAnnote]
+  deriving Semigroup  via [TypeAnnote]
+  deriving Monoid     via [TypeAnnote]
+
+
+-- | A type annotation.
+data TypeAnnote
+  = TBuiltin (Builtin Type)         -- ^ Builtin types
+  | TCon TConId [Type]              -- ^ Type constructor, e.g., Option '0
+  | TVar TVarIdx                    -- ^ Type variables, e.g., '0
+  deriving Eq
+
+-- | 'Type' is a type system.
+instance TypeSystem Type where
+  projectBuiltin = Type . (: []) . TBuiltin
+
+  -- | Unwrap the first TBuiltin annotation, if any.
+  injectBuiltin (Type (TBuiltin t : _ )) = Just t
+  injectBuiltin (Type (_          : ts)) = injectBuiltin $ Type ts
+  injectBuiltin (Type []               ) = Nothing
+
+-- | Convenience helper for no type annotations.
+untyped :: Type
+untyped = mempty

--- a/src/Types/Classes.hs
+++ b/src/Types/Classes.hs
@@ -6,8 +6,29 @@ For now, just the polymorphic types.
 
 -}
 
-module Types.Classes (
-  module Types
+{-# LANGUAGE DerivingVia #-}
+module Types.Classes
+  ( Builtin(..)
+  , Type(..)
   ) where
 
-import Types.Poly as Types
+import           Common.Identifiers             ( TConId
+                                                , TVarIdx
+                                                )
+import           Types.TypeSystem               ( Builtin(..)
+                                                , TypeSystem(..)
+                                                )
+
+
+-- | The language of type expressions, e.g., what appears in a type signature.
+data Type
+  = TBuiltin (Builtin Type)         -- ^ Builtin types
+  | TCon TConId [Type]              -- ^ Type constructor, e.g., Option '0
+  | TVar TVarIdx                    -- ^ Type variables, e.g., '0
+  deriving Eq
+
+-- | 'Type' is a type system.
+instance TypeSystem Type where
+  projectBuiltin = TBuiltin
+  injectBuiltin (TBuiltin t) = Just t
+  injectBuiltin _ = Nothing

--- a/src/Types/TypeSystem.hs
+++ b/src/Types/TypeSystem.hs
@@ -45,34 +45,39 @@ class TypeSystem t where
   projectBuiltin :: Builtin t -> t
   injectBuiltin :: t -> Maybe (Builtin t)
 
--- | Helper to construct unit type in any 'TypeSystem'.
+-- | Helper to construct 'Unit' type in any 'TypeSystem'.
 unit :: TypeSystem t => t
 unit = projectBuiltin Unit
 
--- | Helper to construct void type in any 'TypeSystem'.
+-- | Helper to construct 'Void' type in any 'TypeSystem'.
 void :: TypeSystem t => t
 void = projectBuiltin Void
 
--- | Helper to construct reference type in any 'TypeSystem'.
+-- | Helper to construct 'Ref' type in any 'TypeSystem'.
 ref :: TypeSystem t => t -> t
 ref = projectBuiltin . Ref
 
--- | Helper to construct arrow type in any 'TypeSystem'.
+-- | Helper to construct 'Arrow' type in any 'TypeSystem'.
 arrow :: TypeSystem t => t -> t -> t
 arrow a b = projectBuiltin $ Arrow a b
 
--- | Helper to unrap reference in any 'TypeSystem'.
+-- | Helper to unwrap 'Ref' in any 'TypeSystem'.
 deref :: TypeSystem t => t -> Maybe t
 deref t = case injectBuiltin t of
   Just (Ref t') -> Just t'
   _             -> Nothing
 
--- | Decompose an arrow type into a list of argument types and a return type.
-dearrow :: TypeSystem t => t -> ([t], t)
+-- | Helper to unwrap 'Arrow' in any 'TypeSystem'.
+dearrow :: TypeSystem t => t -> Maybe (t, t)
 dearrow t = case injectBuiltin t of
-  Just (Arrow a b) -> let (as, rt) = dearrow b in (a:as, rt)
-  _ -> ([], t)
+  Just (Arrow a b) -> Just (a, b)
+  _ -> Nothing
 
+-- | Decompose an 'Arrow' type into a list of argument types and a return type.
+collectArrow :: TypeSystem t => t -> ([t], t)
+collectArrow t = case dearrow t of
+  Just (a, b) -> let (as, rt) = collectArrow b in (a:as, rt)
+  _ -> ([], t)
 
 {- | The type definition associated with a type constructor.
 


### PR DESCRIPTION
In addition to implemeting this module, I've also made the following changes:

- Let-bindings now have a body. In the grammar, they are a more general form of sequencing.
- Wait statements may now wait on arbitrary expressions rather than just fixed identifiers. So something like `wait (if c then v1 else v2)` is possible.
- Ast and Classes type systems are now expliclty and separately defined.

There are still some things in the AST I don't really know how to desugar/lowering. Most of the desugaring should probably be handled elsewhere anyway. But this is a start, until we have some kind core-sslang in the AST.