### PR TITLE
hotfix: Tweak logic for counting curried params

### DIFF
--- a/src/Front/Check.hs
+++ b/src/Front/Check.hs
@@ -18,10 +18,10 @@ checkRoutineSignatures (A.Program decls) = all checkAnnotations decls
   checkAnnotations (A.Function _ binds _ (A.ReturnType _)) =
     all annotatedOnce binds
   checkAnnotations (A.Function _ binds _ (A.CurriedType ty)) =
-    countParams ty == length binds && all notAnnotated binds
+    countCurried ty >= length binds && all notAnnotated binds
 
-  countParams (A.TArrow _ t2) = 1 + countParams t2
-  countParams _               = 0
+  countCurried (A.TArrow _ t2) = 1 + countCurried t2
+  countCurried _               = 0
 
   annotatedOnce (A.Bind    _   (Just _)) = True
   annotatedOnce (A.TupBind bds (Just _)) = all notAnnotated bds


### PR DESCRIPTION
We should be leaving more robust checking to the typechecker.

In this phase, we just need to make sure the arrow type has at least as many params as binds in the functions. The remaining args in the arrow type can be interpreted as an arrow type return type.