### PR TITLE
Add sections for expressions in LRM

### DIFF
--- a/doc/sslang-lrm.tex
+++ b/doc/sslang-lrm.tex
@@ -506,7 +506,7 @@ Top-level definitions can be summarized by the following grammar.
 We now a present an overview of expressions and language constructs in sslang.
 \begin{grammar}
 <expr> ::= <expr_stm> ";" <expr>
-\alt "let {" <def_let> "}; " <expr>
+\alt "let {" <def_let> ("||" <def_let>)$^{+}$ "}; " <expr>
 \alt <expr_stm>
 
 <expr_stm> ::= <expr_ann> "<- {"  <expr_ann> "}"
@@ -520,8 +520,8 @@ We now a present an overview of expressions and language constructs in sslang.
 
 <expr_blk> ::=  "do {" <expr> "}"
 \alt "loop {" <expr> "}"
-\alt "wait {" <expr_par> "}"
-\alt "par {" <expr_par> "}"
+\alt "wait {" <expr> ("||" <expr>)$^{+}$ "}"
+\alt "par {" <expr> ("||" <expr>)$^{+}$ "}"
 \alt "if" <expr_blk> "{" <expr> "}" <expr_else>$^{?}$
 \alt "while" <expr_blk> "{" <expr> "}"
 \alt "fun" <pat>$^{+}$ "{" expr "}"
@@ -533,15 +533,13 @@ We now a present an overview of expressions and language constructs in sslang.
 <expr_app> ::= <expr_app> <expr_atom>
 \alt <expr_atom>
 
-<expr_par> ::= <expr> "||" <expr_par>
-\alt <expr>
-
 <expr_atom> ::= ["True"|"False"] \texttt{// Bool}
 \alt ["0"-"9"]$^{+}$ \texttt{// Int}
 \alt ["0"-"9"]$^{+}$"."["0"-"9"]$^{*}$ \texttt{// Rational}
 \alt "()" \texttt{// Event}
 \alt "'"["a"-"zA"-"Z"]"'" \texttt{// Char}
 \alt "\""["a"-"zA"-"Z"]$^{+}$"\"" \texttt{// String}
+\alt "(" <expr> ")" \texttt{// Parenthesized expression}
 \end{grammar}
 \subsection{Variables and Literals}
 There are no special rules for referencing variables or literal expressions.
@@ -591,7 +589,7 @@ The value of do-block expressions is unit.
 <loop> ::= "loop {" <expr> "}"
 \alt "while" <expr> "{" <expr> "}"
 \end{grammar}
-sslang loops come in two flavors: unconditional and conditional loops. The former is simply a sequence of expressions that are evaluated until a \texttt{break} expression is encountered The latter is simply while loop that evaluates the sequence of expressions in its body until its condition evaluates to false. The following two code snippets demonstrate how to count to five using these two loop constructs:
+sslang loops come in two flavors: unconditional and conditional loops. The former is simply a sequence of expressions that are evaluated until a \texttt{break} expression is encountered The latter is simply while loop that evaluates the sequence of expressions in its body until its condition evaluates to \texttt{False}. The following two code snippets demonstrate how to count to five using these two loop constructs:
 \begin{lstlisting}
 x <- 0
 loop
@@ -638,9 +636,7 @@ f 1 2 == (fun a b { a + b }) 1 2
 \end{lstlisting}
 \subsection{Parallel Execution}
 \begin{grammar}
-<par> ::= "par {" <expr_par> "}"
-<expr_par> ::= <expr> "||" <expr_par>
-\alt <expr>
+<par> ::= "par {" <expr> ("||" <expr>)$^{+}$ "}"
 \end{grammar}
 Parallel expression execution takes a sequence of routine calls and pauses the current routine's execution until all of the par'd routines return. For example:
 \begin{lstlisting}
@@ -652,7 +648,7 @@ As per SSM Runtime semantics, \texttt{bar} is guaranteed to be executed first be
 The value of a par expression is a tuple containing the return values of the par'd routines.
 \subsection{Waiting}
 \begin{grammar}
-<wait> ::= "wait {" <expr_par> "}"
+<wait> ::= "wait {" <expr> ("||" <expr>)$^{+}$ "}"
 \end{grammar}
 Wait expressions take a sequence of expressions and pauses the routine's execution until any of the expressions is written to. Take for example the routine \texttt{wait_one_of_two}:
 \begin{lstlisting}
@@ -691,7 +687,7 @@ Note that similarly to let bindings, the \texttt{<-} assignment operator creates
 The value of assignment expressions is unit.
 \subsection{Let Bindings}
 \begin{grammar}
-<let> ::= "let {" <def_let>$^{+}$ "}"; <expr>
+<let> ::= "let {" <def_let> ("||" <def_let>)$^{+}$ "}"; <expr>
 \end{grammar}
 
 In let blocks, patterns are bound to mutually-recursive expressions. Patterns have a wide range of use cases, from binding simple identifiers to deconstructing algebraic data types. In the let-block below, we demonstrate the use of patterns while binding three expressions:

--- a/doc/sslang-lrm.tex
+++ b/doc/sslang-lrm.tex
@@ -18,7 +18,7 @@
 \date{2021}
 
 \lstdefinelanguage{sslang}{
-  morekeywords={let,if,then,else,while,after,wait,pipe},
+  morekeywords={let,if,else,while,after,wait,fun,do,loop,match,par},
   morecomment=[l]{//},
   morecomment=[s]{/*}{*/},
   columns=flexible,
@@ -600,7 +600,19 @@ while y != 5
  
 \end{lstlisting}
 \subsection{Lambdas}
-\fixme{todo}
+\begin{grammar}
+<lambda> ::= "fun" <pat>$^{+}$ "{" <expr> "}"
+\end{grammar}
+
+Lambda expressions enable programmers to define unnamed functions on-the-fly and use them immediately in other expressions without having to make a top-level definition.
+
+Note that lambdas may take any number of pattern arguments, which allow for deconstruction of data types or specification of "don't-care" arguments with wildcards.
+
+The following example demonstrates two ways of defining the same lambda, one using the syntactic sugar let-style and the other using the \texttt{fun} keyword:
+\begin{lstlisting}
+let f x y = x + y;
+f 1 2 == (fun a b { a + b }) 1 2
+\end{lstlisting}
 \subsection{Pattern Matching}
 \fixme{todo}
 \subsection{Forking Routines}
@@ -630,7 +642,7 @@ This routine will block until either \texttt{a} or \texttt{b} are written to, wh
 \end{grammar}
 Sequences chain expressions in block-expressions. The value of a sequence is the second expression in the sequence.
 \begin{lstlisting}
-let x = 1 + 1; 5 // The value of x is 5
+(f 1; 5) // The value of the parenthesized expression is 5
 \end{lstlisting}
 
 \newpage

--- a/doc/sslang-lrm.tex
+++ b/doc/sslang-lrm.tex
@@ -540,26 +540,29 @@ We now a present an overview of expressions and language constructs in sslang.
 \alt "'"["a"-"zA"-"Z"]"'" \texttt{// Char}
 \alt "\""["a"-"zA"-"Z"]$^{+}$"\"" \texttt{// String}
 \alt "(" <expr> ")" \texttt{// Parenthesized expression}
+\alt ["a"-"zA"-"Z"] ["a"-"zA"-"Z0"-"9_'"]$^{*}$ \texttt{// Identfier}
 \end{grammar}
-\subsection{Variables and Literals}
-There are no special rules for referencing variables or literal expressions.
+\subsection{Atomic expressions}
+There are no special rules for referencing variables or literals.
 
 The following expression computes the sum of the variable \texttt{x} (defined elsewhere) and 5:
 \begin{lstlisting}
 x + 5
 \end{lstlisting}
-
+% add variables, add parenthesized exprs
 Variables in sslang are simply identifiers composed of alphanumeric characters, underscores, and ticks: \texttt{[a-zA-Z] [a-zA-Z0-9_']*}
 
 There are several literal values for sslang built-in types:
 
 \begin{grammar}
-<literal> ::= ["True"|"False"] \texttt{// Bool}
+<expr_atom> ::= ["True"|"False"] \texttt{// Bool}
 \alt ["0"-"9"]$^{+}$ \texttt{// Int}
 \alt ["0"-"9"]$^{+}$"."["0"-"9"]$^{*}$ \texttt{// Rational}
 \alt "()" \texttt{// Event}
 \alt "'"["a"-"zA"-"Z"]"'" \texttt{// Char}
 \alt "\""["a"-"zA"-"Z"]$^{+}$"\"" \texttt{// String}
+\alt "(" <expr> ")" \texttt{// Parenthesized expression}
+\alt ["a"-"zA"-"Z"] ["a"-"zA"-"Z0"-"9_'"]$^{*}$ \texttt{// Identfier}
 \end{grammar}
 \subsection{Application}
 \begin{grammar}
@@ -582,7 +585,7 @@ Application via juxtaposition can be performed on adjacent literal expressions a
 \begin{grammar}
 <do> ::= "do {" <expr> "}"
 \end{grammar}
-Do-blocks allow for grouping of expressions in a separate scope.
+Do-blocks allow for grouping of expressions without creating a new scope. This is reminiscent of parenthesizing complex expressions.
 The value of do-block expressions is unit.
 \subsection{Loops}
 \begin{grammar}
@@ -619,7 +622,7 @@ else
     x <- 0
 \end{lstlisting}
 
-The value of an if-else expression is the last expression in either of the blocks. The types of the last expressions in the if and the else block must be the same.
+The value of an if-else expression is the last expression in either of the blocks. The types of the last expressions in the \texttt{if} block and the \texttt{else} block  must be the same. When there is no \texttt{else} block provided, the \texttt{if} block must evaluate to a unit type, which means the value of the entire construct is a unit type.
 \subsection{Lambdas}
 \begin{grammar}
 <lambda> ::= "fun" <pat>$^{+}$ "{" <expr> "}"
@@ -634,11 +637,11 @@ The following example demonstrates two ways of defining the same lambda, one usi
 let f x y = x + y;
 f 1 2 == (fun a b { a + b }) 1 2
 \end{lstlisting}
-\subsection{Parallel Execution}
+\subsection{Parallel Evaluation}
 \begin{grammar}
 <par> ::= "par {" <expr> ("||" <expr>)$^{+}$ "}"
 \end{grammar}
-Parallel expression execution takes a sequence of routine calls and pauses the current routine's execution until all of the par'd routines return. For example:
+Parallel expression evaluation takes a sequence of routine calls and pauses the current routine's execution until all of the par'd routines return. For example:
 \begin{lstlisting}
 foo (a: Ref Int)  (b: Ref Int)
     par (bar a) || (baz b)
@@ -665,9 +668,9 @@ The value of a wait expression is unit. However, one can check which variable wa
 
 It is possible to type-annotate expressions for documentation purposes or to concretize type-generic expressions.
 
-In the following code sample, we type-constrain a lambda expression:
+In the following code sample, we type-constrain a lambda expression such that it takes an integer, some other type, but returns an integer:
 \begin{lstlisting}
-((fun x y { x }): Int -> Bool -> Int)
+((fun x y { x }): Int -> a -> Int)
 \end{lstlisting}
 
 \subsection{Instant and Delayed Reference Assignment}

--- a/doc/sslang-lrm.tex
+++ b/doc/sslang-lrm.tex
@@ -503,7 +503,135 @@ Top-level definitions can be summarized by the following grammar.
 \end{grammar}
 
 \section{Expressions}
+\subsection{Variables and Literals}
+There are no special rules for referencing variables or literal expressions.
 
+The following expression computes the sum of the variable \texttt{x} (defined elsewhere) and 5:
+\begin{lstlisting}
+x + 5
+\end{lstlisting}
+
+Variables in sslang are simply identifiers composed of alphanumeric characters, underscores, and ticks: \texttt{[a-zA-Z] [a-zA-Z0-9_']*}
+
+There are several literal values for sslang built-in types:
+
+\begin{grammar}
+<literal> ::= ["True"|"False"] \texttt{// Bool}
+\alt ["0"-"9"]$^{+}$ \texttt{// Int}
+\alt ["0"-"9"]$^{+}$"."["0"-"9"]$^{*}$ \texttt{// Rational}
+\alt "()" \texttt{// Event}
+\alt "'"["a"-"zA"-"Z"]"'" \texttt{// Char}
+\alt "\""["a"-"zA"-"Z"]$^{+}$"\"" \texttt{// String}
+\end{grammar}
+\subsection{Application}
+\begin{grammar}
+<app> ::= <expr_atom>$^{+}$
+
+<expr_atom> ::= <literal>
+\alt "(" <expr> ")"
+\end{grammar}
+
+Application in sslang is specified by juxtaposition of at least two expressions. In the following example, the expressions \texttt{x + 5} and \texttt{y} are applied to \texttt{f}, where \texttt{f} could be a data type constructor or a function:
+\begin{lstlisting}
+f (x + 5) y
+\end{lstlisting}
+
+Application via juxtaposition can be performed on adjacent literal expressions and parenthesized complex expressions, as shown in the grammar above.
+\subsection{Operation Regions}
+\fixme{todo}
+\subsection{Let Bindings}
+\begin{grammar}
+<let> ::= "let {" <def_let>$^{+}$ "}"; <expr>
+\end{grammar}
+
+In let blocks, patterns are bound to mutually-recursive expressions. Patterns have a wide range of use cases, from binding simple identifiers to deconstructing algebraic data types. In the let-block below, we demonstrate the use of patterns while binding three expressions:
+\begin{lstlisting}
+let x = 5                  // Simple binding
+    (y, _) = foo           // Tuple structured binding
+    f a b = let c = a + b  // Syntactic sugar for lambda definition
+            c * 2
+...
+\end{lstlisting}
+Note the careful use of indentation in the let block. In the absence of explicit braces, the pattern section creates an indentation block (hence \texttt{x}, \texttt{(y, _)}, and \texttt{f a b} appearing at the same level) and the expression value section creates an indentation block (hence the expressions \texttt{let c = ...} and \texttt{c * 2} appearing at the same level).
+\subsection{Instant and Delayed Reference Assignment}
+\begin{grammar}
+<assign> ::= <expr> "<- {" <expr> "}"
+\alt "after" <expr> "," <expr> "<- {" <expr> "}"
+\end{grammar}
+References in sslang may be assigned to instantly or after some time period. In the following function definition, we showcase both forms of assignment.
+\begin{lstlisting}
+now_and_later (x: &Int) (y: &Bool)
+    x <- let a = 2
+         a + 5
+    after 5 ms , y <- True
+\end{lstlisting}
+Note that similarly to let bindings, the \texttt{<-} assignment operator creates an indentation block, as seen in the instant assignment to \texttt{x}.
+\subsection{If-Else}
+\begin{grammar}
+<if-else> ::= "if" <expr> "{" <expr> "}" ("else" "{" <expr> "}")$^{?}$
+\end{grammar}
+If-else expressions conditionally evaluate blocks. If the predicate expression evaluates to \texttt{True}, the \texttt{if} block is evaluated. If there is an \texttt{else} block provided and the predicate evaluated to \texttt{False}, then the \texttt{else} block is evaluated.
+
+Note that If-else creates indentation blocks. This is shown in the following example:
+\begin{lstlisting}
+if x > 5
+    x <- x * 2
+    f x
+else
+    x <- 0
+\end{lstlisting}
+\subsection{Loops}
+\begin{grammar}
+<loop> ::= "loop {" <expr> "}"
+\alt "while" <expr> "{" <expr> "}"
+\end{grammar}
+sslang loops come in two flavors: unconditional and conditional loops. The former is simply a sequence of expressions that are evaluated until a \texttt{break} expression is encountered The latter is simply while loop that evaluates the sequence of expressions in its body until its condition evaluates to false. The following two code snippets demonstrate how to count to five using these two loop constructs:
+\begin{lstlisting}
+x <- 0
+loop
+  if x == 5
+    break
+  else 
+    x <- x + 1
+    
+y <- 0
+while y != 5
+  y <- y + 1
+ 
+\end{lstlisting}
+\subsection{Lambdas}
+\fixme{todo}
+\subsection{Pattern Matching}
+\fixme{todo}
+\subsection{Forking Routines}
+\begin{grammar}
+<fork> ::= "par {" <expr> ("||" <expr>)$^{*}$ "}"
+\end{grammar}
+Fork expressions take a sequence of routine calls and pauses the current routine's execution until all of the forked routines return. For example:
+\begin{lstlisting}
+foo (a: Ref Int)  (b: Ref Int)
+    par (bar a) || (baz b)
+\end{lstlisting}
+As per SSM Runtime semantics, \texttt{bar} is guaranteed to be executed first because the listed routine calls are evaluated in order.
+\subsection{Waiting}
+\begin{grammar}
+<wait> ::= "wait {" <expr> ("||" <expr>)$^{*}$ "}"
+\end{grammar}
+Wait expressions take a sequence of expressions and pauses the routine's execution until any of the expressions is written to. Take for example the routine \texttt{wait_one_of_two}:
+\begin{lstlisting}
+wait_one_of_two (a: Sched Int)  (b: Sched Int)
+    wait a || b
+\end{lstlisting}
+This routine will block until either \texttt{a} or \texttt{b} are written to, where \texttt{a} and  \texttt{b} are scheduled variables.
+
+\subsection{Sequences}
+\begin{grammar}
+<sequence> ::= <expr> ";" <expr>
+\end{grammar}
+Sequences chain expressions in block-expressions. The value of a sequence is the second expression in the sequence.
+\begin{lstlisting}
+let x = 1 + 1; 5 // The value of x is 5
+\end{lstlisting}
 
 \newpage
 

--- a/doc/sslang-lrm.tex
+++ b/doc/sslang-lrm.tex
@@ -503,6 +503,46 @@ Top-level definitions can be summarized by the following grammar.
 \end{grammar}
 
 \section{Expressions}
+We now a present an overview of expressions and language constructs in sslang.
+\begin{grammar}
+<expr> ::= <expr_stm> ";" <expr>
+\alt "let {" <def_let> "}; " <expr>
+\alt <expr_stm>
+
+<expr_stm> ::= <expr_ann> "<- {"  <expr_ann> "}"
+\alt "after" <expr_ann> "," <expr_ann> "<- {"  <expr_ann> "}"
+\alt <expr_ann>
+
+<expr_ann> ::= <expr_ann> ":" <typ>
+\alt <expr_op>
+
+<expr_op> ::= <expr_blk> <expr_op_region>$^{?}$
+
+<expr_blk> ::=  "do {" <expr> "}"
+\alt "loop {" <expr> "}"
+\alt "wait {" <expr_par> "}"
+\alt "par {" <expr_par> "}"
+\alt "if" <expr_blk> "{" <expr> "}" <expr_else>$^{?}$
+\alt "while" <expr_blk> "{" <expr> "}"
+\alt "fun" <pat>$^{+}$ "{" expr "}"
+\alt <expr_app>
+
+<expr_else> ::= "; else {" <expr> "}"
+\alt "else {" <expr> "}"
+
+<expr_app> ::= <expr_app> <expr_atom>
+\alt <expr_atom>
+
+<expr_par> ::= <expr> "||" <expr_par>
+\alt <expr>
+
+<expr_atom> ::= ["True"|"False"] \texttt{// Bool}
+\alt ["0"-"9"]$^{+}$ \texttt{// Int}
+\alt ["0"-"9"]$^{+}$"."["0"-"9"]$^{*}$ \texttt{// Rational}
+\alt "()" \texttt{// Event}
+\alt "'"["a"-"zA"-"Z"]"'" \texttt{// Char}
+\alt "\""["a"-"zA"-"Z"]$^{+}$"\"" \texttt{// String}
+\end{grammar}
 \subsection{Variables and Literals}
 There are no special rules for referencing variables or literal expressions.
 
@@ -537,49 +577,15 @@ f (x + 5) y
 \end{lstlisting}
 
 Application via juxtaposition can be performed on adjacent literal expressions and parenthesized complex expressions, as shown in the grammar above.
+
 \subsection{Operation Regions}
 \fixme{todo}
-\subsection{Let Bindings}
+\subsection{Do-blocks}
 \begin{grammar}
-<let> ::= "let {" <def_let>$^{+}$ "}"; <expr>
+<do> ::= "do {" <expr> "}"
 \end{grammar}
-
-In let blocks, patterns are bound to mutually-recursive expressions. Patterns have a wide range of use cases, from binding simple identifiers to deconstructing algebraic data types. In the let-block below, we demonstrate the use of patterns while binding three expressions:
-\begin{lstlisting}
-let x = 5                  // Simple binding
-    (y, _) = foo           // Tuple structured binding
-    f a b = let c = a + b  // Syntactic sugar for lambda definition
-            c * 2
-...
-\end{lstlisting}
-Note the careful use of indentation in the let block. In the absence of explicit braces, the pattern section creates an indentation block (hence \texttt{x}, \texttt{(y, _)}, and \texttt{f a b} appearing at the same level) and the expression value section creates an indentation block (hence the expressions \texttt{let c = ...} and \texttt{c * 2} appearing at the same level).
-\subsection{Instant and Delayed Reference Assignment}
-\begin{grammar}
-<assign> ::= <expr> "<- {" <expr> "}"
-\alt "after" <expr> "," <expr> "<- {" <expr> "}"
-\end{grammar}
-References in sslang may be assigned to instantly or after some time period. In the following function definition, we showcase both forms of assignment.
-\begin{lstlisting}
-now_and_later (x: &Int) (y: &Bool)
-    x <- let a = 2
-         a + 5
-    after 5 ms , y <- True
-\end{lstlisting}
-Note that similarly to let bindings, the \texttt{<-} assignment operator creates an indentation block, as seen in the instant assignment to \texttt{x}.
-\subsection{If-Else}
-\begin{grammar}
-<if-else> ::= "if" <expr> "{" <expr> "}" ("else" "{" <expr> "}")$^{?}$
-\end{grammar}
-If-else expressions conditionally evaluate blocks. If the predicate expression evaluates to \texttt{True}, the \texttt{if} block is evaluated. If there is an \texttt{else} block provided and the predicate evaluated to \texttt{False}, then the \texttt{else} block is evaluated.
-
-Note that If-else creates indentation blocks. This is shown in the following example:
-\begin{lstlisting}
-if x > 5
-    x <- x * 2
-    f x
-else
-    x <- 0
-\end{lstlisting}
+Do-blocks allow for grouping of expressions in a separate scope.
+The value of do-block expressions is unit.
 \subsection{Loops}
 \begin{grammar}
 <loop> ::= "loop {" <expr> "}"
@@ -599,6 +605,23 @@ while y != 5
   y <- y + 1
  
 \end{lstlisting}
+The value of loop and while expressions is unit.
+\subsection{If-Else}
+\begin{grammar}
+<if-else> ::= "if" <expr> "{" <expr> "}" ("else" "{" <expr> "}")$^{?}$
+\end{grammar}
+If-else expressions conditionally evaluate blocks. If the predicate expression evaluates to \texttt{True}, the \texttt{if} block is evaluated. If there is an \texttt{else} block provided and the predicate evaluated to \texttt{False}, then the \texttt{else} block is evaluated.
+
+Note that If-else creates indentation blocks. This is shown in the following example:
+\begin{lstlisting}
+if x > 5
+    x <- x * 2
+    f x
+else
+    x <- 0
+\end{lstlisting}
+
+The value of an if-else expression is the last expression in either of the blocks. The types of the last expressions in the if and the else block must be the same.
 \subsection{Lambdas}
 \begin{grammar}
 <lambda> ::= "fun" <pat>$^{+}$ "{" <expr> "}"
@@ -613,21 +636,23 @@ The following example demonstrates two ways of defining the same lambda, one usi
 let f x y = x + y;
 f 1 2 == (fun a b { a + b }) 1 2
 \end{lstlisting}
-\subsection{Pattern Matching}
-\fixme{todo}
-\subsection{Forking Routines}
+\subsection{Parallel Execution}
 \begin{grammar}
-<fork> ::= "par {" <expr> ("||" <expr>)$^{*}$ "}"
+<par> ::= "par {" <expr_par> "}"
+<expr_par> ::= <expr> "||" <expr_par>
+\alt <expr>
 \end{grammar}
-Fork expressions take a sequence of routine calls and pauses the current routine's execution until all of the forked routines return. For example:
+Parallel expression execution takes a sequence of routine calls and pauses the current routine's execution until all of the par'd routines return. For example:
 \begin{lstlisting}
 foo (a: Ref Int)  (b: Ref Int)
     par (bar a) || (baz b)
 \end{lstlisting}
 As per SSM Runtime semantics, \texttt{bar} is guaranteed to be executed first because the listed routine calls are evaluated in order.
+
+The value of a par expression is a tuple containing the return values of the par'd routines.
 \subsection{Waiting}
 \begin{grammar}
-<wait> ::= "wait {" <expr> ("||" <expr>)$^{*}$ "}"
+<wait> ::= "wait {" <expr_par> "}"
 \end{grammar}
 Wait expressions take a sequence of expressions and pauses the routine's execution until any of the expressions is written to. Take for example the routine \texttt{wait_one_of_two}:
 \begin{lstlisting}
@@ -636,14 +661,62 @@ wait_one_of_two (a: Sched Int)  (b: Sched Int)
 \end{lstlisting}
 This routine will block until either \texttt{a} or \texttt{b} are written to, where \texttt{a} and  \texttt{b} are scheduled variables.
 
+The value of a wait expression is unit. However, one can check which variable was written to using the \texttt{@} operator.
+\subsection{Type-constrained expressions}
+\begin{grammar}
+<expr_ann> ::= <expr_ann> ":" <typ>
+\end{grammar}
+
+It is possible to type-annotate expressions for documentation purposes or to concretize type-generic expressions.
+
+In the following code sample, we type-constrain a lambda expression:
+\begin{lstlisting}
+((fun x y { x }): Int -> Bool -> Int)
+\end{lstlisting}
+
+\subsection{Instant and Delayed Reference Assignment}
+\begin{grammar}
+<assign> ::= <expr> "<- {" <expr> "}"
+\alt "after" <expr> "," <expr> "<- {" <expr> "}"
+\end{grammar}
+References in sslang may be assigned to instantly or after some time period. In the following function definition, we showcase both forms of assignment.
+\begin{lstlisting}
+now_and_later (x: &Int) (y: &Bool)
+    x <- let a = 2
+         a + 5
+    after 5 ms , y <- True
+\end{lstlisting}
+Note that similarly to let bindings, the \texttt{<-} assignment operator creates an indentation block, as seen in the instant assignment to \texttt{x}.
+
+The value of assignment expressions is unit.
+\subsection{Let Bindings}
+\begin{grammar}
+<let> ::= "let {" <def_let>$^{+}$ "}"; <expr>
+\end{grammar}
+
+In let blocks, patterns are bound to mutually-recursive expressions. Patterns have a wide range of use cases, from binding simple identifiers to deconstructing algebraic data types. In the let-block below, we demonstrate the use of patterns while binding three expressions:
+\begin{lstlisting}
+let x = 5                  // Simple binding
+    (y, _) = foo           // Tuple structured binding
+    f a b = let c = a + b  // Syntactic sugar for lambda definition
+            c * 2
+...
+\end{lstlisting}
+Note the careful use of indentation in the let block. In the absence of explicit braces, the pattern section creates an indentation block (hence \texttt{x}, \texttt{(y, _)}, and \texttt{f a b} appearing at the same level) and the expression value section creates an indentation block (hence the expressions \texttt{let c = ...} and \texttt{c * 2} appearing at the same level).
+
+The value of a let-binding expression is the last expression in the sequence following the bindings.
 \subsection{Sequences}
 \begin{grammar}
-<sequence> ::= <expr> ";" <expr>
+<seq> ::= <expr_stm> ";" <expr>
 \end{grammar}
 Sequences chain expressions in block-expressions. The value of a sequence is the second expression in the sequence.
 \begin{lstlisting}
 (f 1; 5) // The value of the parenthesized expression is 5
 \end{lstlisting}
+
+
+\subsection{Pattern Matching}
+\fixme{todo}
 
 \newpage
 


### PR DESCRIPTION
Outstanding items:

- [x] Format and Style (I chose grammar -> blurb -> example)
- [x] Lambdas
- [x] Pattern-matching (leaving as TODO)
- [x] Op Regions (leaving as TODO)