### PR TITLE
Fix builds on macOS

### DIFF
--- a/lib/ssm/Makefile
+++ b/lib/ssm/Makefile
@@ -23,24 +23,20 @@ OBJECTS = $(patsubst src/%.c, build/%.o, $(SOURCES))
 EXAMPLES = $(wildcard examples/*.c)
 EXAMPLEEXES = $(patsubst examples/%.c, build/%, $(EXAMPLES))
 
-RED = \e[31m
-GREEN = \e[32m
-RESET_COLOR = \e[0m
-
 ARFLAGS = -cr
 
 all : test-examples test_main
 
 test_main : build/test_main
-	./build/test_main > build/test_main.out || echo "${RED}TEST_MAIN FAILED${RESET_COLOR}"
+	./build/test_main > build/test_main.out || echo "TEST_MAIN FAILED"
 	@(diff test/test_main.out build/test_main.out && \
-	echo "${GREEN}TEST_MAIN PASSED${RESET_COLOR}") || \
-	echo "${RED}TEST_MAIN OUTPUT DIFFERS${RESET_COLOR}"
+	echo "TEST_MAIN PASSED") || \
+	echo "TEST_MAIN OUTPUT DIFFERS"
 test-examples : examples
 	./runexamples > build/examples.out
 	@(diff test/examples.out build/examples.out && \
-	echo "${GREEN}EXAMPLES PASSED${RESET_COLOR}") || \
-	echo "${RED}EXAMPLE OUTPUT DIFFERS${RESET_COLOR}"
+	echo "EXAMPLES PASSED") || \
+	echo "EXAMPLE OUTPUT DIFFERS"
 
 build/test_main : test/test_main.c build/libssm.a
 	$(CC) $(CFLAGS) -o $@ test/test_main.c -Lbuild -lssm

--- a/lib/ssm/Makefile
+++ b/lib/ssm/Makefile
@@ -64,9 +64,7 @@ build/libssm.a : $(INCLUDES) $(OBJECTS)
 	rm -f build/libssm.a
 	$(AR) $(ARFLAGS) build/libssm.a $(OBJECTS)
 
-$(OBJECTS) : $(INCLUDES) $(SOURCES)
-
-build/%.o : src/%.c
+build/%.o : src/%.c $(INCLUDES)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 examples : $(EXAMPLEEXES)

--- a/lib/ssm/Makefile
+++ b/lib/ssm/Makefile
@@ -27,7 +27,7 @@ RED = \e[31m
 GREEN = \e[32m
 RESET_COLOR = \e[0m
 
-ARFLAGS = -crU
+ARFLAGS = -cr
 
 all : test-examples test_main
 

--- a/lib/ssm/include/ssm.h
+++ b/lib/ssm/include/ssm.h
@@ -74,8 +74,7 @@ See [the detailed documentation](@ref all)
  * pointer if the linker does not find a definition for this symbol in any
  * object file.
  */
-void ssm_throw(int reason, const char *file, int line, const char *func)
-  __attribute__((weak));
+void ssm_throw(int reason, const char *file, int line, const char *func);
 
 /** Invoked when a process must terminate, e.g., when memory or queue space is
  * exhausted. Not expected to return.
@@ -84,13 +83,7 @@ void ssm_throw(int reason, const char *file, int line, const char *func)
  * Default behavior is to exit with reason as the exit code, but can be
  * overridden by defining ssm_throw.
  */
-#define SSM_THROW(reason) \
-    do \
-      if (ssm_throw) \
-        ssm_throw(reason, __FILE__, __LINE__, __func__); \
-      else \
-        for(;;); \
-    while (0)
+#define SSM_THROW(reason) ssm_throw(reason, __FILE__, __LINE__, __func__)
 
 /** Error codes, indicating reason for failure.
  *

--- a/lib/ssm/src/ssm-scheduler.c
+++ b/lib/ssm/src/ssm-scheduler.c
@@ -297,7 +297,7 @@ void ssm_unschedule(ssm_sv_t *var)
     q_idx_t hole = find_queued_event(var);
     var->later_time = SSM_NEVER;
     ssm_sv_t *moved_var = event_queue[event_queue_len--];
-    if (hole < SSM_QUEUE_HEAD + event_queue_len)
+    if (hole < SSM_QUEUE_HEAD + event_queue_len) {
       // Percolate only if removal led to a hole in the queue; no need to do
       // this if we happened to remove the last element of the queue.
       if (hole == SSM_QUEUE_HEAD ||
@@ -305,6 +305,7 @@ void ssm_unschedule(ssm_sv_t *var)
         event_queue_percolate_down(hole, moved_var);
       else
         event_queue_percolate_up(hole, moved_var);
+    }
   }
 }
 

--- a/lib/ssm/src/ssm-throw.c
+++ b/lib/ssm/src/ssm-throw.c
@@ -1,0 +1,6 @@
+#include <ssm.h>
+
+/** Default, platform-generic implementation of ssm_throw; spins forever. */
+void ssm_throw(int reason, const char *file, int line, const char *func) {
+  for(;;);
+}


### PR DESCRIPTION
NOTE: I intend on keeping these commits separate and rebase them, for cleaner upstreaming, so expect force pushes.

Fixes #35 by dropping `-U` flag (see commit message for details).

Still needs a solution to fix macOS's dodgy support for weak symbols.

One solution is to just case over the platform `[ "$(uname)" == "Darwin" ]` and manually specify `-Wl,-U,_ssm_throw` (following advice from https://stackoverflow.com/a/51755953), but this isn't exactly elegant, and we'll have to do this for every weak symbol. I'm looking into an alternate approach that involves weak aliases, which according to http://maskray.me/blog/2021-04-25-weak-symbol is less error prone (perhaps more uniformly supported?) across different toolchains. Will need some help testing this out; @hmontero1205 @XijiaoLi and @kentjhall , do you have suggestions/cycles to help try some things out.