### PR TITLE
initialize adt c structs

### DIFF
--- a/src/Codegen/Codegen.hs
+++ b/src/Codegen/Codegen.hs
@@ -456,10 +456,11 @@ genExpr a@(I.App _ _ ty) = do
     (I.Data tag t, args) -> do
       (fieldVals, evalStms) <- unzip <$> mapM genExpr args
       tmpName               <- nextTmp t
-      -- Want check if integer or pointer, but that info comes from typedef.hs!
-      -- Either need size and tag number passed in after call to genTypeDef,
+      -- Problem: cannot recover all the info needed from data constructor alone
+      -- Solution: Either need size and pointer/integer status passed in after call to genTypeDef,
       -- or need to generate macros in genTypeDef 
-      let maxArgs = 4::Int -- maxArgs information comes from typedef.hs (same issue)
+      -- assume pointer representation and size 4 for now...
+      let maxArgs = 4::Int 
       let alloc = [[citem|$id:tmpName = ssm_new($int:maxArgs,$id:tag);|]]
       let initField =
             (\x y i -> [citem|$id:x->payload[$int:(i::Int)] = $exp:y;|])

--- a/src/Codegen/Identifiers.hs
+++ b/src/Codegen/Identifiers.hs
@@ -257,3 +257,21 @@ mem_alloc = "malloc"
 -- | Free memory.
 mem_free :: CIdent
 mem_free = "free"
+
+{----- Algebraic Data Types -----}
+
+-- | Type of a generic ADT
+ssm_object_t :: C.Type
+ssm_object_t = [cty|struct ssm_object_t|]
+
+-- | Type of an ADT's memory management header
+ssm_mm_md :: C.Type
+ssm_mm_md = [cty|struct ssm_mm_md|]
+
+-- | Name of an ADT's memory management header
+header :: CIdent
+header = "header"
+
+-- | Name of an ADT's payload
+payload :: CIdent 
+payload = "payload"


### PR DESCRIPTION
I started editing codegen.hs to generate initialization of c structs.
I ran into an issue where I didn't have all the information I needed to determine whether an ADT was an integer or pointer. I think this information needs to be passed into gen expr after the call to genTypeDef (I think  genTypeDef will be called in genTop?), or c macros need to be defined at the same as the adt c struct definitions (genTypeDef should generate C macros). I think the latter would be less invasive but I'd like to hear your thoughts on this.