### PR TITLE
Always make libssm.a

### DIFF
--- a/regression-tests/runtests.sh
+++ b/regression-tests/runtests.sh
@@ -81,8 +81,6 @@ Check() {
     reffile=`echo $1 | sed 's/[.][^.]*$//'`
     basedir=`dirname $1`
 
-    Run make -C "$SSMDIR" build/libssm.a "1>&2"
-
     echo -n "$basename..."
 
     echo 1>&2
@@ -189,6 +187,8 @@ then
 else
     files="tests/*.ssl"
 fi
+
+Run make -C "$SSMDIR" build/libssm.a "1>&2" 2>> $globallog
 
 for file in $files
 do

--- a/regression-tests/runtests.sh
+++ b/regression-tests/runtests.sh
@@ -81,12 +81,8 @@ Check() {
     reffile=`echo $1 | sed 's/[.][^.]*$//'`
     basedir=`dirname $1`
 
-    # If the library isn't there, build it
-    if [ ! -f "${SSMLIBDIR}/libssm.a" ] ; then
-	Run mkdir -p out &&
-	Run make -C "$SSMDIR" build/libssm.a "1>&2"
-    fi
-    
+    Run make -C "$SSMDIR" build/libssm.a "1>&2"
+
     echo -n "$basename..."
 
     echo 1>&2


### PR DESCRIPTION
Previously, the script would lead to a stale library, because it wasn't checking timestamps. This is exactly what Make is for, so we just unconditionally call make.

I tested that:

- It builds the library if it isn't there
- It rebuilds the library if one or more of its dependencies' timestamps are newer than the library

Verified using `touch` and inspecting `runtests.log`.