### PR TITLE
Fix inconsistent type annotation in doubleblink

### DIFF
--- a/regression-tests/tests/doubleblink.ssl
+++ b/regression-tests/tests/doubleblink.ssl
@@ -18,3 +18,4 @@ fast(led : &Int) -> () =
 main(led : &Int) -> () =
   par ((slow: &Int -> ()) (led: &Int): ())
       ((fast: &Int -> ()) (led: &Int): ())
+  ()

--- a/regression-tests/tests/doubleblink2.ssl
+++ b/regression-tests/tests/doubleblink2.ssl
@@ -18,3 +18,4 @@ fast(led : &Int) -> () =
 main(led : &Int) -> () =
   par slow led
       fast led
+  ()


### PR DESCRIPTION
Since the type of `par` should be a tuple, the annotated return type of `main` function (`()`) is inconsistent with the actual type of its function body (`(), ()`). Since currently we not yet support handling tuple type inside codegen, add a dummy `()` at the end of function body so that its type matches the annotated return type.