### PR TITLE
Add type definition syntax

### DIFF
--- a/src/Common/Compiler.hs
+++ b/src/Common/Compiler.hs
@@ -11,6 +11,7 @@ module Common.Compiler
   , fromString
   , runPass
   , dump
+  , unexpected
   , warn
   , passIO
   , liftEither
@@ -86,6 +87,10 @@ runPass (Pass p) = runExcept (runWriterT p)
 -- | Dump pretty-printable output from within a compiler pass.
 dump :: Pretty a => a -> Pass x
 dump = throwError . Dump . show . pretty
+
+-- | Report unexpected compiler error and halt pipeline.
+unexpected :: (MonadError Error m) => String -> m a
+unexpected = throwError . UnexpectedError . fromString
 
 -- | Log a compiler warning.
 warn :: MonadWriter [Warning] m => Warning -> m ()

--- a/src/Front/Ast.hs
+++ b/src/Front/Ast.hs
@@ -14,14 +14,14 @@ newtype Program = Program [TopDef]
 -- | A top-level definition.
 data TopDef
   = TopDef Definition     -- ^ Bind a (data) value to a variable
-  | TopType TypeDef       -- ^ Declare a type
+  | TopType TypeDef       -- ^ Define an algebraic data type
   deriving (Eq, Show)
 
--- | A type definition.
+-- | An algebraic data type definition.
 data TypeDef = TypeDef
   { typeName     :: Identifier      -- ^ The name of the type, e.g., @Option@
   , typeParams   :: [Identifier]    -- ^ List of type parameters, e.g., @a@
-  , typeVariants :: [TypeVariant]   -- ^ List of variants/data constructors
+  , typeVariants :: [TypeVariant]   -- ^ List of variants, e.g., @Some@, @None@
   }
   deriving (Eq, Show)
 

--- a/src/Front/Ast.hs
+++ b/src/Front/Ast.hs
@@ -7,26 +7,29 @@ import           Common.Pretty
 
 import           Data.List                      ( intersperse )
 
--- | A complete program: a list of declarations
+-- | A complete program: a list of top-level definitions.
 newtype Program = Program [TopDef]
   deriving (Eq, Show)
 
+-- | A top-level definition.
 data TopDef
-  = TopDef Definition
-  | TopType TypeDef
+  = TopDef Definition     -- ^ Bind a (data) value to a variable
+  | TopType TypeDef       -- ^ Declare a type
   deriving (Eq, Show)
 
+-- | A type definition.
 data TypeDef = TypeDef
-  { typeName     :: Identifier
-  , typeParams   :: [Identifier]
-  , typeVariants :: [TypeVariant]
+  { typeName     :: Identifier      -- ^ The name of the type, e.g., @Option@
+  , typeParams   :: [Identifier]    -- ^ List of type parameters, e.g., @a@
+  , typeVariants :: [TypeVariant]   -- ^ List of variants/data constructors
   }
   deriving (Eq, Show)
 
+-- | A type variant, i.e., a data constructor.
 data TypeVariant = VariantUnnamed Identifier [Typ]
   deriving (Eq, Show)
 
--- | A value definition
+-- | A value definition.
 data Definition
   = DefFn Identifier [Pat] TypFn Expr
   | DefPat Pat Expr

--- a/src/Front/Ast.hs
+++ b/src/Front/Ast.hs
@@ -8,7 +8,22 @@ import           Common.Pretty
 import           Data.List                      ( intersperse )
 
 -- | A complete program: a list of declarations
-newtype Program = Program [Definition]
+newtype Program = Program [TopDef]
+  deriving (Eq, Show)
+
+data TopDef
+  = TopDef Definition
+  | TopType TypeDef
+  deriving (Eq, Show)
+
+data TypeDef = TypeDef
+  { typeName     :: Identifier
+  , typeParams   :: [Identifier]
+  , typeVariants :: [TypeVariant]
+  }
+  deriving (Eq, Show)
+
+data TypeVariant = VariantUnnamed Identifier [Typ]
   deriving (Eq, Show)
 
 -- | A value definition
@@ -92,18 +107,41 @@ data Literal
 data Fixity = Infixl Int Identifier
             | Infixr Int Identifier
 
--- | Collect a curried application into the function and its list of arguments.
+-- | Collect a type application into the type constructor and its arguments.
 collectTApp :: Typ -> (Typ, [Typ])
 collectTApp (TApp lhs rhs) = (lf, la ++ [rhs])
   where (lf, la) = collectTApp lhs
 collectTApp t = (t, [])
 
+-- | Collect a curried application into the function and its list of arguments.
 collectApp :: Expr -> (Expr, [Expr])
 collectApp (Apply lhs rhs) = (lf, la ++ [rhs]) where (lf, la) = collectApp lhs
 collectApp t               = (t, [])
 
+-- | Unwrap a (potential) top-level data definition.
+getTopDataDef :: TopDef -> Maybe Definition
+getTopDataDef (TopDef d) = Just d
+getTopDataDef _ = Nothing
+
+-- | Unwrap a (potential) top-level type definition.
+getTopTypeDef :: TopDef -> Maybe TypeDef
+getTopTypeDef (TopType t) = Just t
+getTopTypeDef _ = Nothing
+
 instance Pretty Program where
   pretty (Program defs) = vsep (intersperse emptyDoc $ map pretty defs)
+
+instance Pretty TopDef where
+  pretty (TopDef  d) = pretty d
+  pretty (TopType t) = pretty t
+
+instance Pretty TypeDef where
+  pretty TypeDef { typeName = tn, typeParams = tvs, typeVariants = tds } =
+    pretty "type" <+> hsep (pretty tn : map pretty tvs) <+> equals <+> braces
+      (hsep $ punctuate bar $ map pretty tds)
+
+instance Pretty TypeVariant where
+  pretty (VariantUnnamed dc vs) = pretty dc <+> hsep (map pretty vs)
 
 instance Pretty Definition where
   pretty (DefFn fid formals r body) =

--- a/src/Front/ParseOperators.hs
+++ b/src/Front/ParseOperators.hs
@@ -12,6 +12,7 @@ import           Front.Ast                      ( Definition(..)
                                                 , Fixity(..)
                                                 , OpRegion(..)
                                                 , Program(..)
+                                                , TopDef(..)
                                                 )
 
 import           Data.Bifunctor                 ( Bifunctor(..) )
@@ -26,11 +27,14 @@ defaultOps =
   [Infixl 6 "+", Infixl 6 "-", Infixl 7 "*", Infixl 8 "/", Infixr 8 "^"]
 
 parseOperators :: Program -> Compiler.Pass Program
-parseOperators (Program decls) = return $ Program $ map (parseOps defaultOps)
-                                                        decls
+parseOperators (Program decls) = return $ Program $ map (parseTop ops) decls
  where
-  parseOps fs (DefFn v bs t e) = DefFn v bs t $ parseExprOps fs e
-  parseOps fs (DefPat b e    ) = DefPat b $ parseExprOps fs e
+  ops = defaultOps
+  parseTop fs  (TopDef  d) = TopDef $ parseDef fs d
+  parseTop _fs (TopType t) = TopType t
+
+  parseDef fs (DefFn v bs t e) = DefFn v bs t $ parseExprOps fs e
+  parseDef fs (DefPat b e    ) = DefPat b $ parseExprOps fs e
 
 -- | Remove the OpRegion constructs in the AST by parsing the operators
 --   according to the given Fixity specifications

--- a/src/Front/Parser.y
+++ b/src/Front/Parser.y
@@ -279,7 +279,7 @@ matchArms                             --> [(Pat, Expr)]
 
 -- | Each individual arm of a pattern match.
 matchArm                              --> (Pat, Expr)
-  : pat '=' '{' expr '}'                { ($1, $4) }
+  : patAnn '=' '{' expr '}'             { ($1, $4) }
 
 -- | Optional trailing 'else' branch to 'if' statement.
 exprElse                              --> Expr

--- a/src/Front/Parser.y
+++ b/src/Front/Parser.y
@@ -70,6 +70,7 @@ import Data.Bifunctor (first)
 -- | Root node of sslang program parser.
 program                               --> Program
   : topDefs                             { Program $1 }
+  | {- empty -}                         { Program [] }
 
 {- | Top-level definitions.
 
@@ -78,7 +79,7 @@ shift-reduce conflicts.
 -}
 topDefs                               --> [TopDef]
   : topDef '||' topDefs                 { $1 : $3 }
-  | {- empty -}                         { [] }
+  | topDef                              { [$1] }
 
 -- | Top-level definition.
 topDef                                --> TopDef
@@ -96,7 +97,7 @@ defType                               --> TypeDef
 -- | List of pipe-separated variants.
 typeVariants                          --> [TypeVariant]
   : typeVariant '|' typeVariants        { $1 : $3 }
-  |                                     { [] }
+  | typeVariant                         { [$1] }
 
 -- | Variant of an algebraic data type.
 typeVariant                           --> TypeVariant
@@ -118,7 +119,7 @@ defLet                                --> Definition
 -- | A list of juxtaposed pattersn.
 pats                                  -->
   : pat pats                            { $1 : $2 }
-  | {- nothing -}                       { [] }
+  | {- empty -}                         { [] }
 
 -- | Tuple patterns are comma-separated and can be type-annotated.
 patTups                              --> [Pat]
@@ -284,7 +285,7 @@ matchArm                              --> (Pat, Expr)
 exprElse                              --> Expr
   : ';' 'else' '{' expr '}'             { $4 }
   | 'else' '{' expr '}'                 { $3 }
-  | {- nothing -} %prec NOELSE          { NoExpr }
+  | {- empty -} %prec NOELSE            { NoExpr }
 
 -- | Expressions with application by juxtaposition.
 exprApp                               --> Expr
@@ -307,7 +308,7 @@ exprPar                               --> [Expr]
 -- | A list of juxtaposed identifiers.
 ids                                   --> [Identifier]
   : id ids                              { $1 : $2 }
-    | {- empty -}                       { [] }
+  | {- empty -}                         { [] }
 {
 -- | What to do upon encountering parse error.
 parseError :: Token -> Alex a

--- a/src/Front/Parser.y
+++ b/src/Front/Parser.y
@@ -28,6 +28,7 @@ import Data.Bifunctor (first)
 %tokentype { Token }
 
 %token
+  'type'  { Token (_, TType) }
   'if'    { Token (_, TIf) }
   'else'  { Token (_, TElse) }
   'while' { Token (_, TWhile) }
@@ -68,20 +69,38 @@ import Data.Bifunctor (first)
 %%
 -- | Root node of sslang program parser.
 program                               --> Program
-  : defTop                              { Program $1 }
-  -- TODO: support empty program
+  : topDefs                             { Program $1 }
 
 {- | Top-level definitions.
-
-Note that although these also begin with 'let', they are grammatically (and
-indeed semantically) distinct from actual let-bindings (@defLets@).
 
 They are separated with '||' rather than ';' because the latter somehow causes
 shift-reduce conflicts.
 -}
-defTop                                --> [Definition]
-  : defLet '||' defTop                  { $1 : $3 }
-  | defLet                              { [$1] }
+topDefs                               --> [TopDef]
+  : topDef '||' topDefs                 { $1 : $3 }
+  | {- empty -}                         { [] }
+
+-- | Top-level definition.
+topDef                                --> TopDef
+  : defLet                              { TopDef $1 }
+  | defType                             { TopType $1 }
+
+-- | Algebraic data type definition.
+defType                               --> TypeDef
+  : 'type' id ids '{' typeVariants '}'  { TypeDef { typeName = $2
+                                                  , typeParams = $3
+                                                  , typeVariants = $5
+                                                  }
+                                        }
+
+-- | List of pipe-separated variants.
+typeVariants                          --> [TypeVariant]
+  : typeVariant '|' typeVariants        { $1 : $3 }
+  |                                     { [] }
+
+-- | Variant of an algebraic data type.
+typeVariant                           --> TypeVariant
+  : id typs                             { VariantUnnamed $1 $2 }
 
 -- | Mutually recursive block of let-definitions.
 defLets                               --> [Definition]
@@ -97,7 +116,7 @@ defLet                                --> Definition
   : pats typFn '=' '{' expr '}'         {% categorizeDef $1 $2 $5 }
 
 -- | A list of juxtaposed pattersn.
-pats
+pats                                  -->
   : pat pats                            { $1 : $2 }
   | {- nothing -}                       { [] }
 
@@ -141,7 +160,12 @@ patAtom                               --> Pat
   | int                                 { PatLit $ LitInt $1 }
   | id                                  { PatId $1 }
 
--- | Root node for type annotation.
+-- | List of type expressions.
+typs                                  --> [Typ]
+  : typPre typs                         { $1 : $2 }
+  | {- empty -}                         { [] }
+
+-- | Root node for single type expression.
 typ                                   --> Typ
   : typIn                               { $1 }
 
@@ -279,6 +303,11 @@ exprAtom
 exprPar                               --> [Expr]
   : expr '||' exprPar                   { $1 : $3 }
   | expr                                { [$1] }
+
+-- | A list of juxtaposed identifiers.
+ids                                   --> [Identifier]
+  : id ids                              { $1 : $2 }
+    | {- empty -}                       { [] }
 {
 -- | What to do upon encountering parse error.
 parseError :: Token -> Alex a

--- a/src/Front/Scanner.x
+++ b/src/Front/Scanner.x
@@ -103,6 +103,7 @@ tokens :-
     par                 { layout    TPar    TDBar }
     wait                { layout    TWait   TDBar }
     fun                 { layoutNL  TFun    TSemicolon }
+    type                { layoutNL  TType   TBar }
 
     -- | Keywords that just do as they be.
     after               { keyword TAfter }

--- a/src/Front/Scope.hs
+++ b/src/Front/Scope.hs
@@ -50,9 +50,9 @@ module Front.Scope
   ) where
 
 import qualified Front.Ast                     as A
-import           Front.Identifiers              ( DataInfo(dataKind)
-                                                , IdKind(User)
-                                                , TypInfo
+import           Front.Identifiers              ( DataInfo(..)
+                                                , IdKind(..)
+                                                , TypInfo(..)
                                                 , builtinData
                                                 , builtinTypes
                                                 )
@@ -85,7 +85,9 @@ import           Data.List                      ( group
                                                 , sort
                                                 )
 import qualified Data.Map                      as M
-import           Data.Maybe                     ( isJust )
+import           Data.Maybe                     ( isJust
+                                                , mapMaybe
+                                                )
 
 -- | Report 'Identifier' for error reporting.
 showId :: Identifier -> ErrorMsg
@@ -192,7 +194,26 @@ typeRef i = do
 
 -- | Check the scoping of a 'A.Program'.
 scopeProgram :: A.Program -> Pass ()
-scopeProgram (A.Program ds) = runScopeFn $ scopeDefs ds $ return ()
+scopeProgram (A.Program ds) = runScopeFn $ do
+  scopeTypeDefs tds
+  scopeDefs dds $ return ()
+ where
+  tds = mapMaybe A.getTopTypeDef ds
+  dds = mapMaybe A.getTopDataDef ds
+
+scopeTypeDefs :: [A.TypeDef] -> ScopeFn ()
+scopeTypeDefs _tds = undefined
+  {-
+  corecs <- mapM scopeCorec tds
+  ensureUnique $ map fst corecs
+  undefined
+ where
+  scopeCorec :: A.TypeDef -> ScopeFn (Identifier, TypInfo)
+  scopeCorec A.TypeDef { A.typeName = tn } =
+    return (tn, TypInfo { typKind = User })
+
+  scopeTypeDef :: [(Identifier, TypInfo)] -> A.TypeDef -> ScopeFn ()
+  -}
 
 -- | Check the scoping of a set of parallel (co-recursive) 'A.Definition'.
 scopeDefs :: [A.Definition] -> ScopeFn () -> ScopeFn ()

--- a/src/Front/Scope.hs
+++ b/src/Front/Scope.hs
@@ -262,6 +262,7 @@ scopeDCons A.TypeDef { A.typeVariants = tvs, A.typeParams = tps } = do
 -- | Check the scoping of the data constructor a single data variant.
 scopeDcon :: A.TypeVariant -> ScopeFn (Identifier, DataInfo)
 scopeDcon (A.VariantUnnamed dcon ts) = do
+  ensureCons dcon
   mapM_ scopeType ts
   return (dcon, DataInfo { dataKind = User })
 

--- a/src/Front/Scope.hs
+++ b/src/Front/Scope.hs
@@ -42,8 +42,8 @@ constructors are @Bool@ and @Either@.
 
 The grammar as it appears in the parser does not actually distinguish between
 any of these kinds of identifiers, so it is the responsibility of this module to
-check that, for example, a data constructor does not appear where a data
-variable is expected, e.g., @let F x = e@, or vice versa, e.g., @let f X = e@.
+check that, a data constructor does not appear where a data variable is
+expected, e.g., @let F x = e@, or vice versa, e.g., @let f (x Y) = e@.
 -}
 module Front.Scope
   ( scopeProgram
@@ -93,10 +93,23 @@ import           Data.Maybe                     ( isJust
 showId :: Identifier -> ErrorMsg
 showId s = "'" <> fromString (ident s) <> "'"
 
--- | Scoping environment.
+{- | Scoping environment, maintained during the scoping pass.
+
+In type expressions that act as type annotations, type variables are implicitly
+qualified at the top-level, so any type variable is always in scope. So, an
+annotation like @id : a -> a@ is legal, and means @id : forall a. a -> a@.
+
+However, in the context of type definitions, type variables must be quantified.
+So something like @type T a = D a b@ is illegal because the type variable @b@
+does not appear as a parameter of unary type constructor @T@.
+
+To account for this discrepancy, the 'implicitScheme' field of the scoping
+environment is used to keep track of this context.
+-}
 data ScopeCtx = ScopeCtx
-  { dataMap :: M.Map Identifier DataInfo
-  , typeMap :: M.Map Identifier TypInfo
+  { dataMap        :: M.Map Identifier DataInfo -- ^ Map of in-scope data ids
+  , typeMap        :: M.Map Identifier TypInfo  -- ^ Map of in-scope type ids
+  , implicitScheme :: Bool                      -- ^ Allow implicit type vars
   }
 
 -- | Scoping monad.
@@ -111,13 +124,30 @@ newtype ScopeFn a = ScopeFn (ReaderT ScopeCtx Pass a)
 
 -- | Run a ScopeFn computation.
 runScopeFn :: ScopeFn a -> Pass a
-runScopeFn (ScopeFn m) =
-  runReaderT m ScopeCtx { dataMap = builtinData, typeMap = builtinTypes }
+runScopeFn (ScopeFn m) = runReaderT
+  m
+  ScopeCtx { dataMap        = builtinData
+           , typeMap        = builtinTypes
+           , implicitScheme = True
+           }
+
+-- | Add a list of data identifiers to the scope.
+withTypeScope :: [(Identifier, TypInfo)] -> ScopeFn a -> ScopeFn a
+withTypeScope is =
+  local $ \ctx -> ctx { typeMap = foldr (uncurry M.insert) (typeMap ctx) is }
 
 -- | Add a list of data identifiers to the scope.
 withDataScope :: [(Identifier, DataInfo)] -> ScopeFn a -> ScopeFn a
-withDataScope is = do
+withDataScope is =
   local $ \ctx -> ctx { dataMap = foldr (uncurry M.insert) (dataMap ctx) is }
+
+withExplicitScheme :: [Identifier] -> ScopeFn a -> ScopeFn a
+withExplicitScheme is = local $ \ctx -> ctx
+  { typeMap        = foldr (uncurry M.insert)
+                           (typeMap ctx)
+                           (zip is $ repeat TypInfo { typKind = User })
+  , implicitScheme = False
+  }
 
 -- | Check that an 'Identifier' is not an empty string.
 ensureNonempty :: Identifier -> ScopeFn ()
@@ -188,32 +218,52 @@ dataRef i = do
 typeRef :: Identifier -> ScopeFn ()
 typeRef i = do
   inScope <- asks $ M.member i . typeMap
+  allowImplicit <- asks implicitScheme
   when (not inScope && isCons i) $ do
     throwError $ ScopeError $ "Type constructor is out of scope: " <> showId i
-  -- Type variables are implicitly quantified, so we always allow any.
+  when (not inScope && isVar i && not allowImplicit) $ do
+    throwError $ ScopeError $ "Type variable is not defined: " <> showId i
 
 -- | Check the scoping of a 'A.Program'.
 scopeProgram :: A.Program -> Pass ()
 scopeProgram (A.Program ds) = runScopeFn $ do
-  scopeTypeDefs tds
-  scopeDefs dds $ return ()
+  scopeTypeDefs tds $ scopeDefs dds $ return ()
  where
   tds = mapMaybe A.getTopTypeDef ds
   dds = mapMaybe A.getTopDataDef ds
 
-scopeTypeDefs :: [A.TypeDef] -> ScopeFn ()
-scopeTypeDefs _tds = undefined
-  {-
-  corecs <- mapM scopeCorec tds
-  ensureUnique $ map fst corecs
-  undefined
- where
-  scopeCorec :: A.TypeDef -> ScopeFn (Identifier, TypInfo)
-  scopeCorec A.TypeDef { A.typeName = tn } =
-    return (tn, TypInfo { typKind = User })
+-- | Check the scoping of a set of type definitions.
+scopeTypeDefs :: [A.TypeDef] -> ScopeFn () -> ScopeFn ()
+scopeTypeDefs tds k = do
+  -- Check and collect all type constructors, which are mutually recursive.
+  tcons <- mapM scopeTCons tds
+  ensureUnique $ map fst tcons
+  withTypeScope tcons $ do
+    -- Then, check and collect all data constructors.
+    dcons <- concat <$> mapM scopeDCons tds
+    ensureUnique $ map fst dcons
+    -- Continuation k is checked with all type and data constructors in scope
+    withDataScope dcons k
 
-  scopeTypeDef :: [(Identifier, TypInfo)] -> A.TypeDef -> ScopeFn ()
-  -}
+-- | Check the scoping of a user-defined type constructor.
+scopeTCons :: A.TypeDef -> ScopeFn (Identifier, TypInfo)
+scopeTCons A.TypeDef { A.typeName = tn } = do
+  ensureCons tn
+  return (tn, TypInfo { typKind = User })
+
+-- | Check the scoping of the data constructors of a type definition.
+scopeDCons :: A.TypeDef -> ScopeFn [(Identifier, DataInfo)]
+scopeDCons A.TypeDef { A.typeVariants = tvs, A.typeParams = tps } = do
+  mapM_ ensureVar tps
+  ensureUnique tps
+  withExplicitScheme tps $ do
+    mapM scopeDcon tvs
+
+-- | Check the scoping of the data constructor a single data variant.
+scopeDcon :: A.TypeVariant -> ScopeFn (Identifier, DataInfo)
+scopeDcon (A.VariantUnnamed dcon ts) = do
+  mapM_ scopeType ts
+  return (dcon, DataInfo { dataKind = User })
 
 -- | Check the scoping of a set of parallel (co-recursive) 'A.Definition'.
 scopeDefs :: [A.Definition] -> ScopeFn () -> ScopeFn ()

--- a/src/Front/Token.hs
+++ b/src/Front/Token.hs
@@ -24,6 +24,7 @@ data Span = Span
 -- | The types of tokens that can appear in a sslang source file.
 data TokenType
   = TEOF
+  | TType
   | TIf
   | TElse
   | TWhile
@@ -81,6 +82,7 @@ instance Pretty Span where
 -- | 'Pretty' instance for 'TokenType'. Recovers strings from keywords.
 instance Pretty TokenType where
   pretty TEOF         = mempty
+  pretty TType        = pretty "type"
   pretty TIf          = pretty "if"
   pretty TElse        = pretty "else"
   pretty TWhile       = pretty "while"

--- a/src/IR/IR.hs
+++ b/src/IR/IR.hs
@@ -8,6 +8,7 @@ module IR.IR
   , Alt(..)
   , collectApp
   , VarId(..)
+  , TConId(..)
   , DConId(..)
   , wellFormed
   , collectLambda

--- a/test/lib/Sslang/Test.hs
+++ b/test/lib/Sslang/Test.hs
@@ -40,7 +40,7 @@ location = case reverse callStack of
 --
 -- Based on Test.Hspec.assertEqual, without the 'Eq' and 'Show' instances.
 assertDifference :: HasCallStack => String -> String -> String -> Expectation
-assertDifference preface expected actual =
+assertDifference preface actual expected =
   preface `deepseq` expected `deepseq` actual `deepseq` E.throwIO
     (HUnitFailure location $ ExpectedButGot prefaceMsg expected actual)
  where
@@ -57,9 +57,9 @@ shouldPass a = case runPass a of
 shouldProduce :: (HasCallStack, Show a, Eq a) => Pass a -> a -> Expectation
 shouldProduce actual expected = case runPass actual of
   Right (a, _) -> a `shouldBe` expected
-  Left  a -> assertDifference "Expected success but encountered error"
-                              (show a)
-                              (show expected)
+  Left  a      -> assertDifference "Expected success but encountered error"
+                                   (show a)
+                                   (show expected)
 
 -- | Expect that some 'Pass' successfully produces the same value as another.
 shouldPassAs :: (HasCallStack, Show a, Eq a) => Pass a -> Pass a -> Expectation

--- a/test/text/Tests/ParseLoopSpec.hs
+++ b/test/text/Tests/ParseLoopSpec.hs
@@ -20,7 +20,7 @@ spec = do
             wait clk
         |]
       output = Program
-        [ DefFn
+        [ TopDef $ DefFn
             "main"
             [PatAnn (TApp (TCon "&") (TCon "Int")) (PatId "clk")]
             TypNone

--- a/test/text/Tests/ParsePatternMatchSpec.hs
+++ b/test/text/Tests/ParsePatternMatchSpec.hs
@@ -18,7 +18,7 @@ spec = do
             _  = wait clk
       |]
       output = Program
-        [ DefFn
+        [ TopDef $ DefFn
             "main"
             [ PatTup
                 [ PatAnn (TCon "Int")                   (PatId "x")


### PR DESCRIPTION
Needed for #46, #49, #50, and #60---this syntax will allow user-defined ADTs, so that we can actually test those language features with real programs.

Will conflict a little with #49, which also makes changes to AST, parser, and related components to add syntax for declaring typeclases and defining their instances. @LeoQiao18 , I'm happy to help resolve those merge conflicts.

This PR is still a WIP, but should be done within the next day. Currently, I still have to:

- [x] Extend the scoping pass to add and check user-defined type constructors, and add user-defined data constructors to the data namespace.
- [x] Add parser tests to make sure that this syntax is supported.