### PR TITLE
Mangle identifiers for testing equivalence

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ library:
   - srcloc
   - composition
   - comonad
+  - syb
 
 executables:
   sslc:

--- a/package.yaml
+++ b/package.yaml
@@ -61,6 +61,7 @@ _test-suite: &test-suite
   - template-haskell
   - containers
   - comonad
+  - syb
 
 tests:
   # End-to-end regression tests

--- a/src/Common/Identifiers.hs
+++ b/src/Common/Identifiers.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE OverloadedStrings #-}
 {- | The types of identifiers used across the compiler.
 
 These are defined as newtypes (rather than as type aliases) so that they cannot
@@ -19,18 +21,22 @@ module Common.Identifiers
   , Identifier(..)
   , isCons
   , isVar
+  , mangle
   ) where
 
+import           Common.Pretty                  ( Pretty(..) )
+
+import           Control.Monad.State
 import           Data.Char                      ( isUpper )
+import           Data.Generics
+import qualified Data.Map                      as M
 import           Data.String                    ( IsString(..) )
 
 import           Language.C                     ( Id(..) )
 import           Language.C.Quote               ( ToIdent(..) )
 
-import           Prettyprinter                  ( Pretty(..) )
-
 -- | A basic identifier: just a string
-newtype Identifier = Identifier String deriving (Eq, Ord)
+newtype Identifier = Identifier String deriving (Eq, Ord, Typeable, Data)
 
 -- | Turn a general identifier into a string
 class (IsString i, Ord i) => Identifiable i where
@@ -65,6 +71,8 @@ fromId = fromString . ident
 newtype TConId = TConId Identifier
   deriving Eq
   deriving Ord
+  deriving Typeable
+  deriving Data
   deriving ToIdent via Identifier
   deriving IsString via Identifier
   deriving Identifiable via Identifier
@@ -104,6 +112,8 @@ instance Pretty TVarIdx where
 newtype DConId = DConId Identifier
   deriving Eq
   deriving Ord
+  deriving Typeable
+  deriving Data
   deriving Show via Identifier
   deriving ToIdent via Identifier
   deriving IsString via Identifier
@@ -116,6 +126,8 @@ newtype DConId = DConId Identifier
 newtype FfiId = FfiId Identifier
   deriving Eq
   deriving Ord
+  deriving Typeable
+  deriving Data
   deriving Show via Identifier
   deriving ToIdent via Identifier
   deriving IsString via Identifier
@@ -128,6 +140,8 @@ newtype FfiId = FfiId Identifier
 newtype VarId = VarId Identifier
   deriving Eq
   deriving Ord
+  deriving Typeable
+  deriving Data
   deriving Show via Identifier
   deriving ToIdent via Identifier
   deriving IsString via Identifier
@@ -140,6 +154,8 @@ newtype VarId = VarId Identifier
 newtype FieldId = FieldId Identifier
   deriving Eq
   deriving Ord
+  deriving Typeable
+  deriving Data
   deriving Show via Identifier
   deriving ToIdent via Identifier
   deriving IsString via Identifier

--- a/src/IR/IR.hs
+++ b/src/IR/IR.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+-- | Sslang's intermediate representation and its associated helpers.
 module IR.IR
   ( Program(..)
   , Binder
@@ -34,7 +35,7 @@ import           Data.Data                      ( Data
 
 {- | Top-level compilation unit.
 
-`t' is the type system in use, e.g., "IR.Types.Flat"
+'t' is the type system in use, e.g., "IR.Types.Flat"
 
 -}
 data Program t = Program

--- a/src/IR/IR.hs
+++ b/src/IR/IR.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 module IR.IR
   ( Program(..)
   , Binder
@@ -19,15 +20,17 @@ import           Common.Identifiers             ( Binder
                                                 , TConId(..)
                                                 , VarId(..)
                                                 )
-
-import           Control.Comonad                ( Comonad(..) )
-import           Data.Bifunctor                 ( Bifunctor(..) )
+import           Common.Pretty
 import           IR.Types.TypeSystem            ( TypeDef(..)
                                                 , TypeSystem
                                                 , arrow
                                                 )
 
-import           Common.Pretty
+import           Control.Comonad                ( Comonad(..) )
+import           Data.Bifunctor                 ( Bifunctor(..) )
+import           Data.Data                      ( Data
+                                                , Typeable
+                                                )
 
 {- | Top-level compilation unit.
 
@@ -39,7 +42,7 @@ data Program t = Program
   , programDefs  :: [(VarId, Expr t)]
   , typeDefs     :: [(TConId, TypeDef t)]
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Typeable, Data)
 
 {- | Literal values supported by the language.
 
@@ -49,7 +52,7 @@ data Literal
   = LitIntegral Integer
   | LitBool Bool
   | LitEvent
-  deriving (Show, Eq)
+  deriving (Eq, Show, Typeable, Data)
 
 {- | Primitive operations.
 
@@ -79,7 +82,7 @@ data PrimOp
   | PrimGe      -- ^ greater than or equal to, i.e., x >= y
   | PrimLt      -- ^ less than, i.e., x < y
   | PrimLe      -- ^ less than or equal to, i.e., x <= y
-  deriving (Show, Eq)
+  deriving (Eq, Show, Typeable, Data)
 
 -- | Primitive functions for side-effects and imperative control flow.
 data Primitive
@@ -118,7 +121,7 @@ data Primitive
   {- ^ 'Return e' returns the value 'e' from the current function. -}
   | PrimOp PrimOp
   {- ^ Primitive operator. -}
-  deriving (Show, Eq)
+  deriving (Eq, Show, Typeable, Data)
 
 {- | Expressions, based on the let-polymorphic lambda calculus.
 
@@ -167,7 +170,7 @@ data Expr t
   {- ^ 'Prim p es t' applies primitive 'p' arguments 'es', producing a value
   of type 't'.
   -}
-  deriving (Show, Eq)
+  deriving (Eq, Show, Typeable, Data)
 
 -- | An alternative in a pattern-match.
 data Alt
@@ -177,7 +180,7 @@ data Alt
   -- ^ @AltLit l e@ matches against literal @d@, producing expression @e@.
   | AltDefault Binder
   -- ^ @AltDefault v@ matches anything, and bound to name @v@.
-  deriving (Show, Eq)
+  deriving (Eq, Show, Typeable, Data)
 
 -- | Collect a curried application into the function applied to a list of args.
 collectApp :: Expr t -> (Expr t, [Expr t])

--- a/src/IR/Types/Annotated.hs
+++ b/src/IR/Types/Annotated.hs
@@ -1,5 +1,6 @@
--- | Type annotations, as collected from the Ast.
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+-- | Type annotations, as collected from the Ast.
 module IR.Types.Annotated
   ( Builtin(..)
   , Type(..)
@@ -10,9 +11,13 @@ import           Common.Identifiers             ( TConId
                                                 , TVarId
                                                 )
 import           Common.Pretty
+import           Data.Data                      ( Data
+                                                , Typeable
+                                                )
 import           IR.Types.TypeSystem            ( Builtin(..)
                                                 , TypeSystem(..)
                                                 )
+
 {- | A single term may be annotated by zero or more types.
 
 When multiple exist, it should be assumed that they are equivalent, in the
@@ -23,6 +28,8 @@ represents no type annotation.
 -}
 newtype Type = Type [TypeAnnote]
   deriving Show
+  deriving Typeable
+  deriving Data
   deriving Eq         via [TypeAnnote]
   deriving Semigroup  via [TypeAnnote]
   deriving Monoid     via [TypeAnnote]
@@ -32,7 +39,7 @@ data TypeAnnote
   = TBuiltin (Builtin Type)         -- ^ Builtin types
   | TCon TConId [Type]              -- ^ Type constructor, e.g., Option '0
   | TVar TVarId                     -- ^ Type variables, e.g., '0
-  deriving (Show, Eq)
+  deriving (Show, Eq, Typeable, Data)
 
 -- | `Type' is a type system.
 instance TypeSystem Type where

--- a/src/IR/Types/Annotated.hs
+++ b/src/IR/Types/Annotated.hs
@@ -23,14 +23,14 @@ import           IR.Types.TypeSystem            ( Builtin(..)
 When multiple exist, it should be assumed that they are equivalent, in the
 sense that they can be unified.
 
-Type annotations can be added using '<>' (from `Semigroup'), while 'mempty'
+Type annotations can be added using '<>' (from 'Semigroup'), while 'mempty'
 represents no type annotation.
 -}
 newtype Type = Type [TypeAnnote]
+  deriving Eq
   deriving Show
   deriving Typeable
   deriving Data
-  deriving Eq         via [TypeAnnote]
   deriving Semigroup  via [TypeAnnote]
   deriving Monoid     via [TypeAnnote]
 
@@ -41,7 +41,7 @@ data TypeAnnote
   | TVar TVarId                     -- ^ Type variables, e.g., '0
   deriving (Show, Eq, Typeable, Data)
 
--- | `Type' is a type system.
+-- | 'Type' is a type system.
 instance TypeSystem Type where
   projectBuiltin = Type . (: []) . TBuiltin
 

--- a/src/IR/Types/Classes.hs
+++ b/src/IR/Types/Classes.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DerivingVia #-}
 {- |
 
 Types with Typeclasses, e.g., after type inference
@@ -5,8 +7,6 @@ Types with Typeclasses, e.g., after type inference
 For now, just the polymorphic types.
 
 -}
-
-{-# LANGUAGE DerivingVia #-}
 module IR.Types.Classes
   ( Builtin(..)
   , Type(..)
@@ -14,6 +14,9 @@ module IR.Types.Classes
 
 import           Common.Identifiers             ( TConId
                                                 , TVarIdx
+                                                )
+import           Data.Data                      ( Data
+                                                , Typeable
                                                 )
 import           IR.Types.TypeSystem            ( Builtin(..)
                                                 , TypeSystem(..)
@@ -26,7 +29,7 @@ data Type
   = TBuiltin (Builtin Type)         -- ^ Builtin types
   | TCon TConId [Type]              -- ^ Type constructor, e.g., Option '0
   | TVar TVarIdx                    -- ^ Type variables, e.g., '0
-  deriving (Eq, Show)
+  deriving (Eq, Show, Typeable, Data)
 
 instance TypeSystem Type where
   projectBuiltin = TBuiltin

--- a/src/IR/Types/Flat.hs
+++ b/src/IR/Types/Flat.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {- | Basic type system with only nullary type constants and builtin types.
 
 Features (or lack thereof):
@@ -23,6 +24,9 @@ module IR.Types.Flat
 
 import           Common.Identifiers             ( TConId )
 import           Common.Pretty
+import           Data.Data                      ( Data
+                                                , Typeable
+                                                )
 import           IR.Types.TypeSystem            ( Builtin(..)
                                                 , TypeSystem(..)
                                                 )
@@ -31,7 +35,7 @@ import           IR.Types.TypeSystem            ( Builtin(..)
 data Type
   = TBuiltin (Builtin Type) -- ^ Builtin types
   | TCon TConId             -- ^ Type constructors
-  deriving (Eq, Show)
+  deriving (Eq, Show, Typeable, Data)
 
 instance TypeSystem Type where
   projectBuiltin = TBuiltin

--- a/src/IR/Types/Poly.hs
+++ b/src/IR/Types/Poly.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {- | Type system supporting (parametric) polymorphism.
 
 Based on the Hindley-Milner-Damas type system and the definitions in
@@ -34,6 +35,9 @@ import           Common.Identifiers             ( TConId
                                                 , TVarIdx
                                                 )
 import           Common.Pretty
+import           Data.Data                      ( Data
+                                                , Typeable
+                                                )
 import           IR.Types.TypeSystem            ( Builtin(..)
                                                 , TypeSystem(..)
                                                 )
@@ -44,7 +48,7 @@ data Type
   = TBuiltin (Builtin Type)         -- ^ Builtin types
   | TCon TConId [Type]              -- ^ Type constructor, e.g., @Option '0@
   | TVar TVarIdx                    -- ^ Type variables, e.g., @'0@
-  deriving (Eq, Show)
+  deriving (Eq, Show, Typeable, Data)
 
 instance TypeSystem Type where
   projectBuiltin = TBuiltin

--- a/src/IR/Types/TypeSystem.hs
+++ b/src/IR/Types/TypeSystem.hs
@@ -20,7 +20,7 @@ Types.Flat: concrete only
 module IR.Types.TypeSystem where
 
 import           Common.Identifiers             ( DConId
-                                                , FieldId
+                                                , VarId
                                                 )
 import           Common.Pretty
 
@@ -40,7 +40,7 @@ data Builtin t
   | Arrow t t     -- ^ Function arrow @a -> b@
   | Tuple [t]     -- ^ Tuple with two or more fields
   | Integral Int  -- ^ Two's complement binary type with size in bits
-  deriving (Eq, Show)
+  deriving (Eq, Show, Typeable, Data)
 
 instance Functor Builtin where
   fmap _ Unit           = Unit
@@ -138,8 +138,8 @@ data TypeDef t = TypeDef
 
 -- | Arguments to a data constructor, whose fields may or may not be named
 data TypeVariant t
-  = VariantNamed [(FieldId, t)] -- ^ A record with named fields
-  | VariantUnnamed [t]          -- ^ An algebraic type with unnamed fields
+  = VariantNamed [(VarId, t)] -- ^ A record with named fields
+  | VariantUnnamed [t]        -- ^ An algebraic type with unnamed fields
   deriving (Show, Eq, Typeable, Data)
 
 instance Functor TypeDef where

--- a/src/IR/Types/TypeSystem.hs
+++ b/src/IR/Types/TypeSystem.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {- | Common definitions for the type system(s) used in this compiler.
 
 The following is a sketch of the type pipeline (from top to bottom):
@@ -21,9 +22,12 @@ module IR.Types.TypeSystem where
 import           Common.Identifiers             ( DConId
                                                 , FieldId
                                                 )
-import           Data.Bifunctor                 ( Bifunctor(second) )
-
 import           Common.Pretty
+
+import           Data.Bifunctor                 ( Bifunctor(second) )
+import           Data.Data                      ( Data
+                                                , Typeable
+                                                )
 
 -- | The number of arguments a type constructor will take.
 type Arity = Int
@@ -130,13 +134,13 @@ data TypeDef t = TypeDef
   { variants :: [(DConId, TypeVariant t)]
   , arity    :: Arity
   }
-  deriving (Show, Eq)
+  deriving (Show, Eq, Typeable, Data)
 
 -- | Arguments to a data constructor, whose fields may or may not be named
 data TypeVariant t
   = VariantNamed [(FieldId, t)] -- ^ A record with named fields
   | VariantUnnamed [t]          -- ^ An algebraic type with unnamed fields
-  deriving (Show, Eq)
+  deriving (Show, Eq, Typeable, Data)
 
 instance Functor TypeDef where
   fmap f TypeDef { variants = vs, arity = a } =

--- a/test/text/Tests/PrettyAstSpec.hs
+++ b/test/text/Tests/PrettyAstSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 module Tests.PrettyAstSpec where
 
-import Sslang.Test ( here, it, shouldPassAs, Spec, Pass )
+import Sslang.Test ( here, it, shouldPassExactlyAs, Spec, Pass )
 
 import           Common.Pretty                  ( spaghetti )
 import           Front.Ast                      ( Program )
@@ -21,7 +21,7 @@ spec = do
               wait clk
         |]
         output = input >>= renderAndParse
-    input `shouldPassAs` output
+    input `shouldPassExactlyAs` output
 
   it "prints a function with a postfix type signature" $ do
     let input = parseProgram [here|
@@ -30,7 +30,7 @@ spec = do
             oth <- 5
         |]
         output = input >>= renderAndParse
-    input `shouldPassAs` output
+    input `shouldPassExactlyAs` output
 
   it "prints a function with an inline type signature" $ do
     let input = parseProgram [here|
@@ -39,7 +39,7 @@ spec = do
             oth <- 5
         |]
         output = input >>= renderAndParse
-    input `shouldPassAs` output
+    input `shouldPassExactlyAs` output
 
   it "prints a function with no type signature" $ do
     let input = parseProgram [here|
@@ -48,7 +48,7 @@ spec = do
             oth <- 5
         |]
         output = input >>= renderAndParse
-    input `shouldPassAs` output
+    input `shouldPassExactlyAs` output
 
   it "prints a function with a pattern match" $ do
     let input = parseProgram [here|
@@ -58,4 +58,4 @@ spec = do
               _  = wait clk
         |]
         output = input >>= renderAndParse
-    input `shouldPassAs` output
+    input `shouldPassExactlyAs` output

--- a/test/trans/Tests/LiftProgramLambdasSpec.hs
+++ b/test/trans/Tests/LiftProgramLambdasSpec.hs
@@ -32,10 +32,10 @@ spec = do
           bar: Int = 5
           baz x: Int -> Int =
             x + 1
-          anon0 z: Int -> Int =
+          anonymous z: Int -> Int =
             z + 1
           foo y: Int -> Int =
-            let adder = anon0
+            let adder = anonymous
             adder y
         |]
     unlifted `shouldPassAs` lifted

--- a/test/trans/Tests/NormalizeSpec.hs
+++ b/test/trans/Tests/NormalizeSpec.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE QuasiQuotes #-}
+-- | Sanity check test suite for equivalent and unequivalent programs.
+module Tests.NormalizeSpec where
+
+import           Sslang.Test
+
+import           Common.Identifiers             ( mangleVars )
+import qualified Front
+import qualified IR
+import qualified IR.IR                         as I
+import           IR.LambdaLift                  ( liftProgramLambdas )
+import           IR.Types.Annotated            as I
+
+parseIR :: String -> Pass (I.Program I.Type)
+parseIR s = Front.run def s >>= IR.lower def
+
+spec :: Spec
+spec = do
+  it "accepts equivalence under data variable renaming" $ do
+    let foo0 = parseIR [here|
+          foo x y = x + y
+          bar z = foo z
+        |]
+        foo1 = parseIR [here|
+          foo y x = y + x
+          bar z = foo z
+        |]
+        foo2 = parseIR [here|
+          bar z foo = z + foo
+          yy x = bar x
+        |]
+        foo0' = parseIR [here|
+          foo x y = y + x
+          bar z = foo z
+        |]
+        foo1' = parseIR [here|
+          foo y x = x + y
+          bar z = foo z
+        |]
+        foo2' = parseIR [here|
+          foo x y = x + y
+          bar z = bar z
+        |]
+    foo0 `shouldPassAs` foo1
+    foo0 `shouldPassAs` foo2
+    foo1 `shouldPassAs` foo2
+    fmap mangleVars foo0 `shouldNotPassAs` fmap mangleVars foo0'
+    fmap mangleVars foo0 `shouldNotPassAs` fmap mangleVars foo1'
+    fmap mangleVars foo0 `shouldNotPassAs` fmap mangleVars foo2'
+
+    let p0 = parseIR [here|
+          bar: Int = 5
+          baz x: Int -> Int =
+            x + 1
+          foo y: Int -> Int =
+            let adder (z: Int) -> Int = z + bar
+            adder y
+        |]
+        p1 = parseIR [here|
+          z: Int = 5
+          a b: Int -> Int =
+            b + 1
+          c d: Int -> Int =
+            let e (f: Int) -> Int = f + z
+            e d
+        |]
+    p0 `shouldPassAs` p1
+
+  it "accepts equivalence under type variable renaming" $ do
+    let i0 = parseIR [here|
+          id a : a -> a = a
+        |]
+        i1 = parseIR [here|
+          id a : b -> b = a
+        |]
+        i2 = parseIR [here|
+          id b : a -> a = b
+        |]
+        i3 = parseIR [here|
+          id b : b -> b = b
+        |]
+    i0 `shouldPassAs` i1
+    i0 `shouldPassAs` i2
+    i0 `shouldPassAs` i3
+    i1 `shouldPassAs` i2
+    i1 `shouldPassAs` i3
+    i2 `shouldPassAs` i3
+
+    let const0 = parseIR [here|
+          const a b : a -> b -> a = a
+        |]
+        const1 = parseIR [here|
+          const b a : a -> b -> a = b
+        |]
+        const2 = parseIR [here|
+          const b a : b -> a -> b = b
+        |]
+        const0' = parseIR [here|
+          const a b : a -> b -> a = b
+        |]
+        const1' = parseIR [here|
+          const a b : b -> a -> a = a
+        |]
+    const0 `shouldPassAs` const1
+    const0 `shouldPassAs` const2
+    fmap mangleVars const0 `shouldNotPassAs` fmap mangleVars const0'
+    fmap mangleVars const0 `shouldNotPassAs` fmap mangleVars const1'


### PR DESCRIPTION
The following two programs are equivalent:

```
id a : a -> a = a
```

```
foo bar : baz -> baz = bar
```

and yet directly testing for exact equivalence will fail to recognize that these are not just semantically but _structurally_ equivalent.

This PR introduces a lightweight mechanism for telling the tests how not to split hairs over _specific_ identifiers, which may be compiler-generated and thus unstable, yet otherwise semanticaly insignificant.

This PR uses a technique first described in the ["Scrap Your Boilerplate" paper](https://www.microsoft.com/en-us/research/publication/scrap-your-boilerplate-with-class/), which had been sitting open in my browser for a few ~weeks~ months at this point. The technique is implemented in the [syb package](https://hackage.haskell.org/package/syb-0.7.2.1).

This essentially gives us an extremely extensible way of mapping over _any_ user-defined ADT, and map only over specific types embedded in that ADT structure. For example, we can ask it to traverse through any ADT and apply some transformation over all `String` types, or sum together all the `Int`s inside, or monadically mangle all `VarId`s therein.

In other words, it allows us to _generically_ traverse over any ADT---perfect for when we are dealing with large, sprawling ASTs and IRs. The only boilerplate we have to actually do for any data type we define is derive `Typeable` and `Data` instances.

@hmontero1205 and @XijiaoLi this should help you write tests for your passes without worrying about the specific names you generate; would appreciate a review from either or both of you.

In this PR, I'll also clean up the comments and stuff in `Common.Identifiers` and `IR.IR`, since I'm touching those files anyway.