### PR TITLE
Automatically deploy Haddock documentation

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -30,9 +30,11 @@ runs:
         stack-version: latest
 
     - name: Setup Haskell Stack
+      shell: bash
       run: |
         stack setup --resolver ${{ inputs.resolver }}
 
     - name: Install dependencies
+      shell: bash
       run: |
         stack build --no-terminal --only-dependencies

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,38 @@
+name: "Setup cached build environment"
+description: "Setup the build using cache"
+inputs:
+  os:
+    description: "Operating system: Linux, Windows or macOS"
+    required: true
+  resolver:
+    description: "Stack resolver"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Stack files
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.stack
+          .stack-work
+        # tie cache to Stack resolver and package config
+        # https://raehik.github.io/2021/03/01/caching-stack-and-cabal-haskell-builds-on-github-actions.html
+        key: ${{ inputs.os }}-stack-${{ inputs.resolver }}-${{ hashFiles('stack.yaml.lock', 'package.yaml') }}
+        restore-keys: |
+          ${{ inputs.os }}-stack-${{ inputs.resolver }}-
+          ${{ inputs.os }}-stack-
+
+    - name: Install Haskell Stack
+      uses: haskell/actions/setup@v1
+      with:
+        enable-stack: true
+        stack-version: latest
+
+    - name: Setup Haskell Stack
+      run: |
+        stack setup --resolver ${{ inputs.resolver }}
+
+    - name: Install dependencies
+      run: |
+        stack build --no-terminal --only-dependencies

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,33 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**'
+      - 'src/**'
+
+jobs:
+  doc-build-html:
+    name: "Build and Deploy Haddock documentation"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build
+      with:
+        os:  ${{ matrix.os }}
+        resolver: ${{ matrix.resolver }}
+
+    - name: Build documentation
+      run: |
+        stack haddock
+
+    - name: Deploy documentation
+      if: ${{ github.ref == 'refs/heads/main' }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./haddock-out
+        publish_branch: gh-pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,44 +30,18 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         resolver: [lts-18.6]
-    env:
-      ARGS: "--stack-yaml stack.yaml --no-terminal --system-ghc"
 
     steps:
-    - name: Check out repo
-      uses: actions/checkout@v2
-
-    - name: Cache Stack files
-      uses: actions/cache@v2
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build
       with:
-        path: |
-          ~/.stack
-          .stack-work
-        # tie cache to Stack resolver and package config
-        # https://raehik.github.io/2021/03/01/caching-stack-and-cabal-haskell-builds-on-github-actions.html
-        key: ${{ matrix.os }}-stack-${{ matrix.resolver }}-${{ hashFiles('stack.yaml.lock', 'package.yaml') }}
-        restore-keys: |
-          ${{ matrix.os }}-stack-${{ matrix.resolver }}-
-          ${{ matrix.os }}-stack-
+        os:  ${{ matrix.os }}
+        resolver: ${{ matrix.resolver }}
 
-    - name: Install Haskell Stack
-      uses: haskell/actions/setup@v1
-      with:
-        enable-stack: true
-        stack-version: latest
-
-    - name: Setup Haskell Stack
+    - name: Build sslang compiler
       run: |
-        stack setup --resolver ${{ matrix.resolver }}
+        stack build
 
-    - name: Install dependencies
-      run: |
-        stack build ${ARGS} --only-dependencies
-
-    - name: Build
-      run: |
-        stack build ${ARGS}
-
-    - name: Test
+    - name: Run sslang test suite
       run: |
         stack test --stack-yaml stack.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - '.github/**'
+      - 'package.yaml'
+      - 'stack.yaml'
+      - 'stack.yaml.lock'
       - 'app/**'
       - 'lib/**'
       - 'regression-tests/**'
@@ -15,6 +18,7 @@ on:
   pull_request:
     paths:
       - '.github/**'
+      - '*.yml'
       - 'app/**'
       - 'lib/**'
       - 'regression-tests/**'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # sslang
 
+![tests](https://github.com/ssm-lang/ssm-runtime/actions/workflows/test.yml/badge.svg?branch=dev)
+[![doc](https://github.com/ssm-lang/ssm-runtime/actions/workflows/doc.yml/badge.svg?branch=dev)](https://ssm-lang.github.io/sslang)
+
 A language built atop the Sparse Synchronous Model.
 
 ## Quickstart


### PR DESCRIPTION
Should come after #72 , but strictly speaking orthogonal

This will automatically deploy the code documentation to the `gh-pages` branch, which we will serve using GitHub Pages.

This PR also moves the Stack setup action (with its cached environment) into a separate, reusable action.