### PR TITLE
Fix doc build CI

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Build documentation
       run: |
-        stack haddock
+        stack haddock --no-haddock-deps
 
     - name: Deploy documentation
       if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -7,6 +7,12 @@ on:
     paths:
       - '.github/**'
       - 'src/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/**'
+      - 'src/**'
 
 jobs:
   doc-build-html:
@@ -17,8 +23,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-build
       with:
-        os:  ${{ matrix.os }}
-        resolver: ${{ matrix.resolver }}
+        os: ubuntu-latest
+        resolver: lts-18.6
 
     - name: Build documentation
       run: |


### PR DESCRIPTION
the old recipe was missing a build strategy that specifies a resolver and os, and that was hidden by the lack of a hook to run it during a PR. 