### PR TITLE
Substitute primitives

### DIFF
--- a/src/IR/IR.hs
+++ b/src/IR/IR.hs
@@ -8,13 +8,14 @@ module IR.IR
   , Primitive(..)
   , Expr(..)
   , Alt(..)
-  , collectApp
   , VarId(..)
   , TConId(..)
   , DConId(..)
   , wellFormed
   , collectLambda
   , makeLambdaChain
+  , zipApp
+  , unzipApp
   ) where
 import           Common.Identifiers             ( Binder
                                                 , DConId(..)
@@ -87,9 +88,8 @@ data PrimOp
 -- | Primitive functions for side-effects and imperative control flow.
 data Primitive
   = New
-  {- ^ @New e t@ allocates a schedule variable initialized to @e@, and
-  returns a reference to it. If reuse token @t@ is non-null,
-  this will use token @t@ instead of allocating new memory.
+  {- ^ @New e@ allocates a schedule variable initialized to @e@, and
+  returns a reference to it.
   -}
   | Dup
   {- ^ @Dup r@ duplicates the reference @r@ (i.e., increments its
@@ -98,10 +98,6 @@ data Primitive
   | Drop
   {- ^ @Drop r@ brings reference @r@ out of scope, and frees it if it
   is the last remaining reference to the scheduled variable.
-  -}
-  | Reuse
-  {- ^ @Reuse r@ is like @Drop r@, except it returns a reuse token
-  that should be passed to @New@ for reuse.
   -}
   | Deref
   {- ^ @Deref r@ dereferences reference @r@ to obtain its value. -}
@@ -180,11 +176,36 @@ data Alt
   -- ^ @AltDefault v@ matches anything, and bound to name @v@.
   deriving (Eq, Show, Typeable, Data)
 
--- | Collect a curried application into the function applied to a list of args.
-collectApp :: Expr t -> (Expr t, [Expr t])
-collectApp (App lhs rhs _) =
-  let (fn, args) = collectApp lhs in (fn, args ++ [rhs])
-collectApp e = (e, [])
+{- | Collect a curried application into the function and argument list.
+
+The type accompanying each argument represents type produced by the
+application, and is extracted from the 'App' node that this function unwraps.
+
+For example, the term @f a b@ (where @a: A@ and @b: B@) would be represented by
+the following AST:
+@@
+(App (App (Var f (A -> B -> C)) (Var a A) (B -> C)) (Var b B) C)
+@@
+
+which, when unzipped, gives:
+
+@@
+(Var f (A -> B -> C)) [(Var a A, B -> C), (Var b B, C)]
+@@
+
+'unzipApp' is the inverse of 'zipApp'.
+-}
+unzipApp :: Expr t -> (Expr t, [(Expr t, t)])
+unzipApp (App lhs rhs t) =
+  let (fn, args) = unzipApp lhs in (fn, args ++ [(rhs, t)])
+unzipApp e = (e, [])
+
+{- | Apply a function to zero or more arguments.
+
+'zipApp' is the inverse of 'unzipApp'.
+-}
+zipApp :: Expr t -> [(Expr t, t)] -> Expr t
+zipApp = foldr $ \(a, t) f -> App f a t
 
 -- | Collect a curried list of function arguments from a nesting of lambdas.
 collectLambda :: Expr t -> ([Binder], Expr t)
@@ -268,7 +289,6 @@ wellFormed (Prim   p    es   _) = wfPrim p es && all wellFormed es
   wfPrim New                 [_]       = True
   wfPrim Dup                 [_]       = True
   wfPrim Drop                [_]       = True
-  wfPrim Reuse               [_]       = True
   wfPrim Deref               [_]       = True
   wfPrim Assign              [_, _]    = True
   wfPrim After               [_, _, _] = True
@@ -318,7 +338,6 @@ instance Pretty t => Pretty (Expr t) where
   pretty (Prim New   [r] t) = typeAnn t $ pretty "new" <+> pretty r
   pretty (Prim Dup   [r] t) = typeAnn t $ pretty "__dup" <+> pretty r
   pretty (Prim Drop  [r] t) = typeAnn t $ pretty "__drop" <+> pretty r
-  pretty (Prim Reuse [r] t) = typeAnn t $ pretty "__reuse" <+> pretty r
   pretty (Prim Deref [r] t) = typeAnn t $ pretty "deref" <+> pretty r
   pretty (Prim Assign [l, r] t) =
     typeAnn t $ parens $ pretty l <+> pretty "<-" <+> braces (pretty r)

--- a/src/IR/SubstMagic.hs
+++ b/src/IR/SubstMagic.hs
@@ -1,0 +1,44 @@
+-- | Substitute AST nodes with magical primitives.
+{-# LANGUAGE OverloadedStrings #-}
+module IR.SubstMagic
+  ( substMagic
+  ) where
+
+import qualified IR.IR                         as I
+
+import           Data.Data                      ( Proxy(..) )
+import           Data.Generics                  ( Data(..)
+                                                , everywhere
+                                                , mkT
+                                                )
+
+{- | Substitute AST nodes with magical primitives.
+
+Implemented as a syb-style generic tree traversal.
+
+Example usage:
+
+@@
+-- Given:
+myExpr :: Expr Poly.Type
+
+-- Do:
+substMagic (Proxy :: Proxy Poly.Type) myExpr
+
+-- Given:
+myProm :: Program Annotated.Type
+
+-- Do:
+substMagic (Proxy :: Proxy Annotated.Type) myProg
+@@
+-}
+substMagic :: (Data t, Data a) => Proxy t -> a -> a
+substMagic p = everywhere $ mkT $ substMagicExpr p
+
+-- | Replace applications to built-in names with corresponding primitives.
+substMagicExpr :: Proxy t -> I.Expr t -> I.Expr t
+substMagicExpr _ e = case I.unzipApp e of
+  (I.Var "new"  _, (a, t) : ats) -> I.zipApp (I.Prim I.New [a] t) ats
+  (I.Var "dup"  _, (a, t) : ats) -> I.zipApp (I.Prim I.Dup [a] t) ats
+  (I.Var "drop" _, (a, t) : ats) -> I.zipApp (I.Prim I.Drop [a] t) ats
+  _                              -> e


### PR DESCRIPTION
Still incomplete, but the substitution logic is remarkably easy thanks to SYB-style generic programming.

I still need to tweak the lexer to accept identifiers like `#new` etc. and then fix the scope checker to allow those.