### PR TITLE
Setup CI environment with test dependencies for faster CI

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -12,6 +12,7 @@ runs:
   steps:
     - name: Cache Stack files
       uses: actions/cache@v2
+      id: cache
       with:
         path: |
           ~/.stack
@@ -23,13 +24,6 @@ runs:
           ${{ inputs.os }}-stack-${{ inputs.resolver }}-
           ${{ inputs.os }}-stack-
 
-    - name: Install Ubuntu dependencies
-      if: ${{ inputs.os == 'ubuntu-latest' }}
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y build-essential gcc valgrind clang
-
     - name: Install Haskell Stack
       uses: haskell/actions/setup@v1
       with:
@@ -38,11 +32,13 @@ runs:
 
     - name: Setup Haskell Stack
       shell: bash
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         stack setup --resolver ${{ inputs.resolver }}
 
     - name: Install dependencies
       shell: bash
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         stack build --test --no-run-tests --no-terminal --only-dependencies
         # Run with --test environment to ensure test dependencies are installed.

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -44,4 +44,5 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        stack build --no-terminal --only-dependencies
+        stack build --test --no-run-tests --no-terminal --only-dependencies
+        # Run with --test environment to ensure test dependencies are installed.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: ./.github/actions/setup-build
+    - name: Setup Stack environment
+      uses: ./.github/actions/setup-build
       with:
         os:  ${{ matrix.os }}
         resolver: ${{ matrix.resolver }}
+
+    - name: Install Ubuntu dependencies
+      if: ${{ inputs.os == 'ubuntu-latest' }}
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential gcc valgrind clang
 
     - name: Build sslang compiler
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Build sslang compiler
       run: |
-        stack build
+        stack build --test --no-run-tests
 
     - name: Run sslang test suite
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         resolver: ${{ matrix.resolver }}
 
     - name: Install Ubuntu dependencies
-      if: ${{ inputs.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       shell: bash
       run: |
         sudo apt-get update


### PR DESCRIPTION
CI is _still_ frustratingly slow (#64). It turns out our workflow is recompiling the test dependencies every single time, meaning they aren't being cached properly. I'm using this branch to see if I can speed this up.