### PR TITLE
Support quoted inline C syntax

### DIFF
--- a/regression-tests/tests/inlinec-hello1.ssl
+++ b/regression-tests/tests/inlinec-hello1.ssl
@@ -1,11 +1,11 @@
-$$
+$$$
 #include <stdio.h>
 
 void hello()
 {
   printf("Hello world!\n");
 }
-$$
+$$$
 
 main _ _ =
   $hello ()

--- a/regression-tests/tests/inlinec-printf1.ssl
+++ b/regression-tests/tests/inlinec-printf1.ssl
@@ -1,11 +1,11 @@
-$$
+$$$
 #include <stdio.h>
 
 void printInt(ssm_value_t v)
 {
   printf("%d\n", ssm_unmarshal(v));
 }
-$$
+$$$
 
 main _ _ =
   $printInt(42)

--- a/regression-tests/tests/inlinec-printf2.out
+++ b/regression-tests/tests/inlinec-printf2.out
@@ -1,0 +1,1 @@
+Hello, 42, world!

--- a/regression-tests/tests/inlinec-printf2.ssl
+++ b/regression-tests/tests/inlinec-printf2.ssl
@@ -1,0 +1,11 @@
+$$$
+#include <stdio.h>
+
+void printInt(int i, const char *s)
+{
+  printf("Hello, %d, %s!\n", i, s);
+}
+$$$
+
+main _ _ =
+  $printInt($$42$$, $$"world"$$)

--- a/src/Front/Ast.hs
+++ b/src/Front/Ast.hs
@@ -87,6 +87,7 @@ data Expr
   | Seq Expr Expr
   | Break
   | Match Expr [(Pat, Expr)]
+  | CQuote String
   | CCall Identifier [Expr]
   deriving (Eq, Show)
 
@@ -230,6 +231,8 @@ instance Pretty Expr where
   pretty (Id  i      ) = pretty i
   pretty (Lit l      ) = pretty l
   pretty Break         = pretty "break"
+  -- TODO: we should replace every '$$' in s with '$$$$'
+  pretty (CQuote s) = pretty "$$" <> pretty s <> pretty "$$"
   pretty (CCall s as) =
     pretty "$" <> pretty s <+> parens (hsep $ punctuate comma $ map pretty as)
   pretty (Match s as) = parens $ pretty "match" <+> pretty s <+> braces

--- a/src/Front/Parser.y
+++ b/src/Front/Parser.y
@@ -63,6 +63,7 @@ import Data.Bifunctor (first)
   op      { Token (_, TOp $$) }
   id      { Token (_, TId $$) }
   cblock  { Token (_, TCBlock $$) }
+  cquote  { Token (_, TCQuote $$) }
   csym    { Token (_, TCSym $$) }
 
 %left ';' -- Helps with if-then-else
@@ -304,6 +305,7 @@ exprApp                               --> Expr
 exprAtom
   : int                                 { Lit (LitInt $1) }
   | string                              { Lit (LitString $1) }
+  | cquote                              { CQuote $1 }
   | id                                  { Id $1 }
   | '(' expr ')'                        { $2 }
   | '(' ')'                             { Lit LitEvent }

--- a/src/Front/Pattern/Anomaly.hs
+++ b/src/Front/Pattern/Anomaly.hs
@@ -116,6 +116,7 @@ checkExpr (A.Seq e1 e2       )     = checkExprs [e1, e2]
 checkExpr A.Break                  = return ()
 checkExpr (A.Match e arms) =
   let (ps, es) = unzip arms in checkExpr e >> checkExprs es >> checkPats ps
+checkExpr (A.CQuote _  ) = return ()
 checkExpr (A.CCall _ es) = mapM_ checkExpr es
 
 checkOpRegion :: A.OpRegion -> AnomalyFn ()

--- a/src/Front/Pattern/Desugar.hs
+++ b/src/Front/Pattern/Desugar.hs
@@ -122,7 +122,8 @@ desugarExpr (A.Match e arms) = do -- INFO: the only important one
     _      -> do
       v <- freshVar
       singleLet v e <$> desugarMatch [v] armsForDesugar A.NoExpr -- INFO: for now, default expression is NoExpr
-desugarExpr (A.CCall s es) = A.CCall s <$> mapM desugarExpr es
+desugarExpr e@(A.CQuote _  ) = return e
+desugarExpr (  A.CCall s es) = A.CCall s <$> mapM desugarExpr es
 
 desugarOpRegion :: A.OpRegion -> DesugarFn A.OpRegion
 desugarOpRegion (A.NextOp i e opRegion) =
@@ -334,7 +335,8 @@ substId old new = substExpr
   substExpr (A.Match e arms) =
     let substArm (p, body) = (p, substExpr body)
     in  A.Match (substExpr e) (map substArm arms)
-  substExpr (A.CCall s es) = A.CCall s $ map substExpr es
+  substExpr e@(A.CQuote _  ) = e
+  substExpr (  A.CCall s es) = A.CCall s $ map substExpr es
 
 singleLet :: Identifier -> A.Expr -> A.Expr -> A.Expr
 singleLet i e = A.Let [A.DefFn i [] A.TypNone e]

--- a/src/Front/Scope.hs
+++ b/src/Front/Scope.hs
@@ -337,6 +337,7 @@ scopeExpr (A.OpRegion e o) =
     <> fromString (show e)
     <> " "
     <> fromString (show o)
+scopeExpr (A.CQuote _  ) = return ()
 scopeExpr (A.CCall _ es) = mapM_ scopeExpr es
 scopeExpr A.NoExpr =
   throwError $ UnexpectedError "NoExpr should not be reachable"

--- a/src/Front/Token.hs
+++ b/src/Front/Token.hs
@@ -60,6 +60,7 @@ data TokenType
   | TId Identifier
   | TOp Identifier
   | TCSym Identifier
+  | TCQuote String
   | TCBlock String
   deriving (Eq, Show)
 
@@ -120,7 +121,8 @@ instance Pretty TokenType where
   pretty (TId      i) = pretty i
   pretty (TOp      o) = pretty o
   pretty (TCSym    s) = pretty $ fromString "$" <> s
-  pretty (TCBlock  b) = pretty $ fromString "$$" <> b <> fromString "$$"
+  pretty (TCQuote  s) = pretty $ fromString "$$" <> s <> fromString "$$"
+  pretty (TCBlock  b) = pretty $ fromString "$$$" <> b <> fromString "$$$"
 
 -- | Pretty print a list of tokens.
 prettyTokens :: [Token] -> String

--- a/src/IR/HM.hs
+++ b/src/IR/HM.hs
@@ -496,6 +496,8 @@ initTypeVars (I.Match cond arms annT) = do
       insertBinder a (Forall [] at')
     initTypeVars rhs
   checkArm (_, rhs) = withNewScope $ initTypeVars rhs
+initTypeVars (I.Prim c@(I.CQuote _) [] annT) = do
+  return $ I.Prim c [] $ collapseAnnT annT
 initTypeVars (I.Prim c@(I.CCall _) es annT) = do
   es' <- mapM initTypeVars es
   t <- typeCheck (collapseAnnT annT) unit
@@ -685,6 +687,7 @@ getType (I.Match cond arms _) = do
       let t      = extract h
       -- type of match is type of one of its arms
       return (I.Match cond' arms'' t)
+getType e@(I.Prim (I.CQuote _) [] _) = return e
 getType (I.Prim c@(I.CCall _) es _) = do
   es' <- mapM getType es
   return $ I.Prim c es' unit -- TODO: handle non-unit return value typet

--- a/src/IR/IR.hs
+++ b/src/IR/IR.hs
@@ -123,6 +123,8 @@ data Primitive
   | Now
   {- ^ @Now@ obtains the value of the current instant -}
   | PrimOp PrimOp
+  {- ^ Inlined C expression code. -}
+  | CQuote String
   {- ^ Primitive operator. -}
   | CCall CSym
   deriving (Eq, Show, Typeable, Data)

--- a/src/IR/LowerAst.hs
+++ b/src/IR/LowerAst.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
 {- | Lower the representation of a sslang Ast into sslang IR.
 
 This pass expects prior desugaring passes to ensure that:
@@ -170,10 +169,11 @@ lowerExpr (A.IfElse c t e) k = I.Match cond [eArm, tArm] (k I.untyped)
   cond = lowerExpr c id
   tArm = (I.AltDefault Nothing, lowerExpr t id)
   eArm = (I.AltLit (I.LitIntegral 0), lowerExpr e id)
+lowerExpr (A.CQuote s) k = I.Prim (I.CQuote $ fromString s) [] (k I.untyped)
 lowerExpr (A.CCall s es) k =
   I.Prim (I.CCall $ fromId s) (map (`lowerExpr` id) es) (k I.untyped)
 lowerExpr (A.OpRegion _ _) _ = error "Should already be desugared"
-lowerExpr A.NoExpr k = I.Lit I.LitEvent (k I.untyped)
+lowerExpr A.NoExpr         k = I.Lit I.LitEvent (k I.untyped)
 
 -- | Lower an A.Pat into an I.Alt
 lowerAlt :: A.Pat -> I.Alt

--- a/src/IR/TypeChecker.hs
+++ b/src/IR/TypeChecker.hs
@@ -261,6 +261,8 @@ inferPrim (I.Prim I.Par es _) = do
   es' <- mapM inferExpr es
   let ts = map extract es'
   return $ I.Prim I.Par es' $ tuple ts
+inferPrim (I.Prim c@(I.CQuote _) [] _) = do
+  return $ I.Prim c [] $ Classes.TVar $ fromString "cquote"
 inferPrim (I.Prim c@(I.CCall _) es _) = do
   es' <- mapM inferExpr es
   return $ I.Prim c es' unit

--- a/test/text/Tests/ParseInlineCSpec.hs
+++ b/test/text/Tests/ParseInlineCSpec.hs
@@ -17,23 +17,23 @@ spec :: Spec
 spec = do
   it "parses inline C blocks" $ do
     shouldParse [here|
-      $$
+      $$$
       #include <stdio.h>
 
       void hello() { printf("Hello world!\n"); }
-      $$
+      $$$
 
       main _ _ =
         $hello ()
     |]
     shouldParse [here|
-      $$
+      $$$
 
       #include <stdio.h>
 
       void printInt(ssm_value_t v) { printf("%d\n", ssm_unmarshal(v)); }
 
-      $$
+      $$$
 
       main _ _ =
         $printInt(42)
@@ -41,67 +41,69 @@ spec = do
 
   it "parses multiple inline C blocks" $ do
     shouldParse [here|
-      $$
+      $$$
 
       #include <stdio.h>
 
-      $$
+      $$$
 
-      $$
+      $$$
 
       void printInt(ssm_value_t v) {
         printf("%d\n", ssm_unmarshal(v));
       }
-      $$
+      $$$
 
       main _ _ =
         $printInt(42)
     |]
     shouldParse [here|
-      $$
+      $$$
       #include <stdio.h>
-      $$
+      $$$
 
       main _ _ =
         $printInt(42)
 
-      $$
+      $$$
 
       void printInt(ssm_value_t v) {
         printf("%d\n", ssm_unmarshal(v));
       }
-      $$
+      $$$
 
     |]
   it "is robust against C syntax errors in C blocks" $ do
     shouldParse [here|
-      $$
+      $$$
       #include <stdio.h
       void printInt(ssm_value_t v) { printf("%d\n", ssm_unmarshal(v)); }
-      $$
+      $$$
 
       main _ _ =
         $printInt(42)
     |]
 
     shouldParse [here|
-      $$
+      $$$
       #include <stdio.h>
       void printInt(ssm_value_t v) { printf("%d\n", ssm_unmarshal(v)); }}}
-      $$
+      $$$
 
       main _ _ =
         $printInt(42)
     |]
 
     shouldParse [here|
-      $$
+      $$$
       ### hello
-      $$$$$ hello
+      $$ hello
+      $$$$$$ hello
+      $$$$$$$ hello
       123 123
       " this is some argi
       aribtrrary text test }} ))(()
-      $$
+      $$$
 
       main _ _ =
         $printInt(42)

--- a/test/text/Tests/ScanInlineCSpec.hs
+++ b/test/text/Tests/ScanInlineCSpec.hs
@@ -9,7 +9,7 @@ import           Front.Scanner                  ( scanTokenTypes )
 import           Front.Token                    ( TokenType(..) )
 
 mkBlock :: String -> String
-mkBlock s = "$$" ++ s ++ "$$"
+mkBlock s = "$$$" ++ s ++ "$$$"
 
 groupChunks :: [TokenType] -> [TokenType]
 groupChunks = foldr groupChunks' []
@@ -18,8 +18,8 @@ groupChunks' t            ts                = t : ts
 
 unescapeSigils :: String -> String
 unescapeSigils = foldr unescapeSigils' []
-unescapeSigils' '$' ('$' : '$' : '$' : ss) = '$' : '$' : ss
-unescapeSigils' s   ss                     = s : ss
+unescapeSigils' '$' ('$' : '$' : '$' : '$' : '$' : ss) = '$' : '$' : '$' : ss
+unescapeSigils' s   ss = s : ss
 
 spec :: Spec
 spec = do
@@ -63,7 +63,7 @@ spec = do
     let contents = [here|
             blocks containing
             escaped block end tokens
-            i.e., this: $$$$
+            i.e., this: $$$$$$
             shoudl still be ok
           |]
     (groupChunks <$> scanTokenTypes (mkBlock contents))


### PR DESCRIPTION
Note that this PR includes brekaing changes to syntax. In particular, C definition blocks are now delimited by `$$$`; we're now using `$$` to delimit quoted C expression literals.