### PR TITLE
Non-invasive Nix + Nix Flake dev shell support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ haddock-out/
 runtests.log
 regression-tests/out
 
+.envrc
+
 # Created by https://www.toptal.com/developers/gitignore/api/haskell
 # Edit at https://www.toptal.com/developers/gitignore?templates=haskell
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1661720780,
+        "narHash": "sha256-AJNGyaB2eKZAYaPNjBZOzap87yL+F9ZLaFzzMkvega0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a63021a330d8d33d862a8e29924b42d73037dd37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,14 +14,8 @@
 
         myDevTools = [
           hPkgs.ghc # GHC compiler in the desired version (will be available on PATH)
-          hPkgs.ghcid # Continous terminal Haskell compile checker
-          hPkgs.ormolu # Haskell formatter
           hPkgs.hlint # Haskell codestyle checker
-          hPkgs.hoogle # Lookup Haskell documentation
           hPkgs.haskell-language-server # LSP server for editor
-          hPkgs.implicit-hie # auto generate LSP hie.yaml file from cabal
-          hPkgs.retrie # Haskell refactoring tool
-          # hPkgs.cabal-install
           stack-wrapped
           pkgs.zlib # External C library needed by some Haskell packages
         ];
@@ -44,8 +38,7 @@
               "
           '';
         };
-      in
-      {
+      in {
         devShells.default = pkgs.mkShell {
           buildInputs = myDevTools;
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "sslang: a language built atop the Sparse Synchronous Model";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        hPkgs =
+          pkgs.haskell.packages."ghc8107"; # need to match Stackage LTS version
+        # from stack.yaml resolver
+
+        myDevTools = [
+          hPkgs.ghc # GHC compiler in the desired version (will be available on PATH)
+          hPkgs.ghcid # Continous terminal Haskell compile checker
+          hPkgs.ormolu # Haskell formatter
+          hPkgs.hlint # Haskell codestyle checker
+          hPkgs.hoogle # Lookup Haskell documentation
+          hPkgs.haskell-language-server # LSP server for editor
+          hPkgs.implicit-hie # auto generate LSP hie.yaml file from cabal
+          hPkgs.retrie # Haskell refactoring tool
+          # hPkgs.cabal-install
+          stack-wrapped
+          pkgs.zlib # External C library needed by some Haskell packages
+        ];
+
+        # Wrap Stack to work with our Nix integration. We don't want to modify
+        # stack.yaml so non-Nix users don't notice anything.
+        # - no-nix: We don't want Stack's way of integrating Nix.
+        # --system-ghc    # Use the existing GHC on PATH (will come from this Nix file)
+        # --no-install-ghc  # Don't try to install GHC if no matching GHC found on PATH
+        stack-wrapped = pkgs.symlinkJoin {
+          name = "stack"; # will be available as the usual `stack` in terminal
+          paths = [ pkgs.stack ];
+          buildInputs = [ pkgs.makeWrapper ];
+          postBuild = ''
+            wrapProgram $out/bin/stack \
+              --add-flags "\
+                --no-nix \
+                --system-ghc \
+                --no-install-ghc \
+              "
+          '';
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = myDevTools;
+
+          # Make external Nix c libraries like zlib known to GHC, like
+          # pkgs.haskell.lib.buildStackProject does
+          # https://github.com/NixOS/nixpkgs/blob/d64780ea0e22b5f61cd6012a456869c702a72f20/pkgs/development/haskell-modules/generic-stack-builder.nix#L38
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath myDevTools;
+        };
+      });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,3 @@
+{ system ? builtins.currentSystem }:
+
+(builtins.getFlake (toString ./.)).devShells.${system}


### PR DESCRIPTION
Stack and Nix have overlapping responsiblities when it comes to package management. Although Stack has the ability to integrate with Nix, I believe that it is not good to change the Stack configurations just to make this play well with Nix on Nix/NixOS systems.

It turns out that Tweag had a post that discusses this, providing a solution that integrates stack and nix in a "smooth and non-invasive" way. For more information, read the [blog](https://www.tweag.io/blog/2022-06-02-haskell-stack-nix-shell/). In order to have more explicit version pinning, this PR is using a version that extends on the idea in the blog and make use of Nix Flake. This is taken from a [section](https://docs.haskellstack.org/en/stable/nix_integration/#supporting-both-nix-and-non-nix-developers) in Stack's documentation.

In the future, the only maintenance needed for this is to sync the GHC version in `flake.nix` with the GHC version for the resolver being used in Stack.

For those on NixOS or systems with Nix that have Flake enabled, you can drop into the nix development shell using either `nix develop` or `nix-shell`. This also allows users to use `nix-direnv`. However, when I tested with `lorri`, it runs into some error... I'll investigate into this later.

Recall that I was having trouble accessing the regression tests when executing `stack test`. This PR fixes that issue as well! So this is important for at least me... 