### PR TITLE
Support all pattern type annotations and check kinds

### DIFF
--- a/src/IR/Types.hs
+++ b/src/IR/Types.hs
@@ -1,3 +1,4 @@
+-- | Wrapper module around other types-related modules and definitions.
 module IR.Types
   ( module IR.Types.Type
   , typecheckProgram

--- a/src/IR/Types/Type.hs
+++ b/src/IR/Types/Type.hs
@@ -30,6 +30,7 @@ import           Data.Foldable                  ( toList )
 import           Data.Generics                  ( Data
                                                 , Typeable
                                                 )
+import qualified Data.Map                      as M
 import qualified Data.Set                      as S
 import           Data.Set                       ( (\\) )
 
@@ -222,6 +223,33 @@ tupleOf (TCon "(,,)"  [a, b, c]   ) = Tup3 (a, b, c)
 tupleOf (TCon "(,,,)" [a, b, c, d]) = Tup4 (a, b, c, d)
 tupleOf t@(TCon _ ts) | isTuple t   = TupN ts
 tupleOf _                           = NotATuple
+
+type Kind = Int
+
+builtinKinds :: M.Map TConId Kind
+builtinKinds =
+  M.fromList
+    $  [ k $ TVar "a" `Arrow` TVar "b"
+       , k Unit
+       , k $ Ref $ TVar "a"
+       , k $ List $ TVar "a"
+       , k Time
+       , k I64
+       , k U64
+       , k I32
+       , k U32
+       , k I16
+       , k U16
+       , k I8
+       , k U8
+       , ("(,)" , 2)
+       , ("(,,)", 3)
+       ]
+    ++ take 8 (map tup [(2 :: Int) ..])
+ where
+  k (TCon tc ts) = (tc, length ts)
+  k _            = error "This should only be used with built-in TCons"
+  tup i = (tupleId i, 2)
 
 instance Pretty Type where
   pretty (Arrow a b) = parens $ pretty a <+> "->" <+> pretty b

--- a/src/IR/Types/Type.hs
+++ b/src/IR/Types/Type.hs
@@ -212,7 +212,7 @@ isNum t = isInt t || isUInt t
 
 -- | Construct a builtin tuple type out of a list of at least 2 types.
 tuple :: [Type] -> Type
-tuple ts 
+tuple ts
   | length ts >= 2 = TCon (tupleId $ length ts) ts
   | otherwise = error $ "Cannot create tuple of arity: " ++ show (length ts)
 
@@ -250,8 +250,10 @@ tupleOf (TCon "(,,,)" [a, b, c, d]) = Tup4 (a, b, c, d)
 tupleOf t@(TCon _ ts) | isTuple t   = TupN ts
 tupleOf _                           = NotATuple
 
+-- | Kinds are just the arity of type constructors.
 type Kind = Int
 
+-- | Map to help us look up the kinds of builtin types.
 builtinKinds :: M.Map TConId Kind
 builtinKinds =
   M.fromList
@@ -274,7 +276,7 @@ builtinKinds =
     ++ take 8 (map tup [(2 :: Int) ..])
  where
   k (TCon tc ts) = (tc, length ts)
-  k _            = error "This should only be used with built-in TCons"
+  k _            = error "This should only be used with (builtin) TCons"
   tup i = (tupleId i, 2)
 
 instance Pretty Type where
@@ -310,11 +312,3 @@ instance Pretty Annotations where
 
 instance Dumpy Annotations where
   dumpy = pretty
-
--- FIXME: convenience for ghci debugging
-scheme :: [String] -> Constraint -> Type -> Scheme
-scheme vs c t = Scheme $ Forall (S.fromList $ map fromString vs) c t
-
--- FIXME: convenience for ghci debugging
-tv :: String -> Type
-tv = TVar . fromString

--- a/src/IR/Types/Type.hs
+++ b/src/IR/Types/Type.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+
+-- | Definitions of and related to the sslang IR's type system.
 module IR.Types.Type where
 
 import           Common.Identifiers             ( DConId(..)
@@ -35,30 +37,35 @@ import qualified Data.Set                      as S
 import           Data.Set                       ( (\\) )
 
 
-{- | The type of sslang types.
+{- | Encoding of sslang types.
 
 Structurally speaking, these are very simple. Types are either type variables or
 type constructors applied to some other types.
 
 Builtin types (and type constructors) include 'Arrow', 'Unit', 'Ref', 'List',
-and various sizes of tuples; for convenience, these are defined using GHC
-extensions PatternSynonyms.
+and various sizes of tuples; for convenience, those are defined elsewhere using
+the GHC PatternSynonyms extension.
 -}
 data Type
-  = TCon TConId [Type]
-  | TVar TVarId
+  = TCon TConId [Type]    -- ^ Type constructor, applied to zero or more types
+  | TVar TVarId           -- ^ Type variable (may be implicitly quantified)
   deriving (Eq, Show, Typeable, Data)
+
+instance HasFreeVars Type TVarId where
+  freeVars (TCon _ ts) = S.unions $ map freeVars ts
+  freeVars Hole        = S.empty
+  freeVars (TVar v)    = S.singleton v
 
 {- | Constraints on a type scheme.
 
 For now, we only support trivial constraints.
 -}
-data Constraint = CTrue
+data Constraint = CTrue -- ^ The trivial constraint, i.e., always satisfied.
   deriving (Eq, Show, Typeable, Data)
 
-{- | Schemes quantify over 'Type' variables and impose 'Constraint'.
+{- | Schemes quantify over 'Type' variables and impose some 'Constraint'.
 
-'SchemeOf' is implemented a functor over some kind of type so that we can easily
+'SchemeOf' is implemented as functor over some kind of type so we can easily
 substitute in 'Type' vs 'UType' when performing type inference/unification.
 -}
 data SchemeOf t = Forall (S.Set TVarId) Constraint t
@@ -68,44 +75,44 @@ data SchemeOf t = Forall (S.Set TVarId) Constraint t
 unScheme :: SchemeOf t -> t
 unScheme (Forall _ _ t) = t
 
--- | Construct a scheme with quantified type variables and a trivial constraint
+-- | Construct a scheme with quantified type variables and a trivial constraint.
 forall :: (Functor l, Foldable l) => l TVarId -> t -> SchemeOf t
 forall vs = Forall (S.fromList $ toList $ fmap fromId vs) CTrue
+
+-- | Construct a scheme from all free type variables and a trivial constraint.
+schemeOf :: Type -> Scheme
+schemeOf t = Scheme $ forall (S.toList $ freeVars t) t
 
 -- | Schemes over 'Type'.
 newtype Scheme = Scheme (SchemeOf Type)
   deriving (Eq, Show, Typeable, Data)
 
+instance HasFreeVars Scheme TVarId where
+  freeVars (Scheme (Forall s _ t)) = freeVars t \\ s
+
 -- | An annotation records the annotated portion of a pattern.
 data Annotation
-  = AnnType Type
-  | AnnDCon DConId [Annotation]
-  | AnnArrows [Annotation] Annotation
+  = AnnType Type                        -- ^ A basic 'Type' annotation
+  | AnnDCon DConId [Annotation]         -- ^ Annotations collected from patterns
+  | AnnArrows [Annotation] Annotation   -- ^ Annotations collected from fun args
   deriving (Eq, Show, Typeable, Data)
 
+-- | Expressions are annotated with a (potentially empty) list of 'Annotation'.
 newtype Annotations = Annotations [Annotation]
   deriving (Eq, Show, Typeable, Data, Semigroup, Monoid)
 
+-- | Unwrap the 'Annotations' data constructor.
 unAnnotations :: Annotations -> [Annotation]
 unAnnotations (Annotations as) = as
 
+-- | Unroll an annotation into a type.
+-- FIXME: get rid of this.
 fromAnnotations :: Annotations -> Type
 fromAnnotations = go . unAnnotations
  where
   go (AnnType t : _   ) = t
   go (_         : anns) = go anns
   go []                 = Hole -- TODO: properly unroll
-
-instance HasFreeVars Type TVarId where
-  freeVars (TCon _ ts) = S.unions $ map freeVars ts
-  freeVars Hole        = S.empty
-  freeVars (TVar v)    = S.singleton v
-
-instance HasFreeVars Scheme TVarId where
-  freeVars (Scheme (Forall s _ t)) = freeVars t \\ s
-
-schemeOf :: Type -> Scheme
-schemeOf t = Scheme $ Forall (freeVars t) CTrue t
 
 -- | Some data type that contains a sslang 'Type'.
 class HasType a where
@@ -117,57 +124,73 @@ instance HasType Type where
 instance HasType Scheme where
   getType (Scheme (Forall _ _ t)) = t
 
--- | May appear in type annotations; indicates a fresh free type variable.
+-- | A fresh, free type variable; may appear in type annotations.
 pattern Hole :: Type
 pattern Hole = TVar "_"
 
+-- | The type constructor for function arrows.
 pattern Arrow :: Type -> Type -> Type
 pattern Arrow a b = TCon "->" [a, b]
 
+-- | Unfold an 'Arrow' 'Type' into a list of argument types and a return type.
 unfoldArrow :: Type -> ([Type], Type)
 unfoldArrow (Arrow a b) = let (as, rt) = unfoldArrow b in (a : as, rt)
 unfoldArrow t           = ([], t)
 
+-- | Fold a list of argument types and a return type into an 'Arrow' 'Type'.
 foldArrow :: ([Type], Type) -> Type
 foldArrow (a : as, rt) = a `Arrow` foldArrow (as, rt)
 foldArrow ([]    , t ) = t
 
+-- | The builtin singleton 'Type', whose only data constructor is just @()@.
 pattern Unit :: Type
 pattern Unit = TCon "()" []
 
+-- | The builtin reference 'Type', created using @new@.
 pattern Ref :: Type -> Type
 pattern Ref a = TCon "&" [a]
 
+-- | The builtin list 'Type', created using list syntax, e.g., @[a, b]@.
 pattern List :: Type -> Type
 pattern List a = TCon "[]" [a]
 
+-- | The builtin 64-bit timestamp 'Type'.
 pattern Time :: Type
 pattern Time = TCon "Time" []
 
+-- | Builtin 'Type' for signed 64-bit integers.
 pattern I64 :: Type
 pattern I64 = TCon "Int64" []
 
+-- | Builtin 'Type' for unsigned 64-bit integers.
 pattern U64 :: Type
 pattern U64 = TCon "UInt64" []
 
+-- | Builtin 'Type' for signed 32-bit integers.
 pattern I32 :: Type
 pattern I32 = TCon "Int32" []
 
+-- | Builtin 'Type' for unsigned 32-bit integers.
 pattern U32 :: Type
 pattern U32 = TCon "UInt32" []
 
+-- | Builtin 'Type' for signed 16-bit integers.
 pattern I16 :: Type
 pattern I16 = TCon "Int16" []
 
+-- | Builtin 'Type' for unsigned 16-bit integers.
 pattern U16 :: Type
 pattern U16 = TCon "UInt16" []
 
+-- | Builtin 'Type' for signed 8-bit integers.
 pattern I8 :: Type
 pattern I8 = TCon "Int8" []
 
+-- | Builtin 'Type' for unsigned 8-bit integers.
 pattern U8 :: Type
 pattern U8 = TCon "UInt8" []
 
+-- | Test whether a 'Type' is one of the builtin signed integers.
 isInt :: Type -> Bool
 isInt I64 = True
 isInt I32 = True
@@ -175,6 +198,7 @@ isInt I16 = True
 isInt I8  = True
 isInt _   = False
 
+-- | Test whether a 'Type' is one of the builtin unsigned integers.
 isUInt :: Type -> Bool
 isUInt U64 = True
 isUInt U32 = True
@@ -182,20 +206,22 @@ isUInt U16 = True
 isUInt U8  = True
 isUInt _   = False
 
+-- | Test whether a 'Type' is one of the builtin numeric types.
 isNum :: Type -> Bool
 isNum t = isInt t || isUInt t
 
+-- | Construct a builtin tuple type out of a list of at least 2 types.
 tuple :: [Type] -> Type
-tuple ts = TCon (tupleId $ length ts) ts
+tuple ts 
+  | length ts >= 2 = TCon (tupleId $ length ts) ts
+  | otherwise = error $ "Cannot create tuple of arity: " ++ show (length ts)
 
--- | Tests whether a 'Type' is a tuple of some arity.
+-- | Test whether a 'Type' is a tuple of some arity.
 isTuple :: Type -> Bool
 isTuple (TCon n ts) | length ts >= 2 = n == tupleId (length ts)
 isTuple _                            = False
 
--- | Construct the name of the built-in tuple type of given arity.
---
--- Fails if arity is less than 2.
+-- | Construct the type constructor of a builtin tuple of given arity (>= 2).
 tupleId :: (Integral i, Identifiable v) => i -> v
 tupleId i
   | i >= 2    = fromString $ "(" ++ replicate (fromIntegral i - 1) ',' ++ ")"

--- a/src/IR/Types/Typechecking.hs
+++ b/src/IR/Types/Typechecking.hs
@@ -3,39 +3,105 @@ module IR.Types.Typechecking
   ( typecheckProgram
   ) where
 
-import           IR.IR
+import           IR.IR                          ( Annotation
+                                                , Annotations
+                                                , DConId
+                                                , Expr
+                                                , Program(..)
+                                                , TConId
+                                                , Type
+                                                , TypeDef(..)
+                                                , TypeVariant(..)
+                                                )
 import           IR.Types.Inference             ( inferProgram )
-import           IR.Types.Type
-
+import           IR.Types.Type                  ( Annotation
+                                                  ( AnnArrows
+                                                  , AnnDCon
+                                                  , AnnType
+                                                  )
+                                                , Type(TCon, TVar)
+                                                , foldArrow
+                                                , unAnnotations
+                                                )
 import qualified Common.Compiler               as Compiler
+
+import           Control.Monad.Reader           ( MonadReader(..)
+                                                , MonadTrans(..)
+                                                , ReaderT(..)
+                                                , unless
+                                                )
 import           Data.Bifunctor                 ( Bifunctor(..) )
+import qualified Data.Map                      as M
+
+type Kind = Int
+type KindEnv = M.Map TConId Kind
+type DConEnv = M.Map DConId ([Type], Type)
+type AnnRavel = ReaderT (KindEnv, DConEnv) Compiler.Pass
 
 typecheckProgram :: Program Annotations -> Compiler.Pass (Program Type)
 typecheckProgram p = do
-  checkTypeDefs $ typeDefs p
-  defs <- unravelAnns $ unwrapAnns $ programDefs p
+  let kenv = M.fromList $ map (second $ length . targs) $ typeDefs p
+  denv <- M.unions <$> mapM (checkTypeDef kenv) (typeDefs p)
+  defs <- (`runReaderT` (kenv, denv)) $ unravelAnns $ unwrapAnns $ programDefs p
   inferProgram $ p { programDefs = defs }
  where
   -- | Unwrap each 'Annotations' into a bare 'Annotation' list.
   unwrapAnns :: [(a, Expr Annotations)] -> [(a, Expr [Annotation])]
   unwrapAnns = fmap $ second $ fmap unAnnotations
 
-  -- | Unravel each 'Annotation' in the list into a 'Type'.
-  unravelAnns :: [(a, Expr [Annotation])] -> Compiler.Pass [(a, Expr [Type])]
+  -- | Unravel each 'Annotation' in the list into a 'Type', and check kindness.
+  unravelAnns :: [(a, Expr [Annotation])] -> AnnRavel [(a, Expr [Type])]
   unravelAnns (unzip -> (bs, es)) = do
-    -- TODO: add more context to support annotations deep inside patterns
-    zip bs <$> mapM (mapM $ mapM unravelAnnotation) es
+    es'       <- mapM (mapM $ mapM unravelAnnotation) es
+    (kenv, _) <- ask
+    lift $ mapM_ (mapM $ mapM $ checkType kenv) es'
+    return $ zip bs es'
 
-unravelAnnotation :: Annotation -> Compiler.Pass Type
-unravelAnnotation (AnnType t) = return t
+checkTypeDef :: KindEnv -> (TConId, TypeDef) -> Compiler.Pass DConEnv
+checkTypeDef kenv (tcon, TypeDef { targs = tvs, variants = vs }) =
+  M.unions <$> mapM variant2env vs
+ where
+  variant2env :: (DConId, TypeVariant) -> Compiler.Pass DConEnv
+  variant2env (dcon, VariantNamed ts) =
+    mapM_ (checkType kenv . snd) ts >> mkDConInfo dcon undefined
+  variant2env (dcon, VariantUnnamed ts) =
+    mapM_ (checkType kenv) ts >> mkDConInfo dcon ts
+
+  mkDConInfo :: DConId -> [Type] -> Compiler.Pass DConEnv
+  mkDConInfo dcon ts = return $ M.singleton dcon (ts, TCon tcon $ map TVar tvs)
+
+checkType :: KindEnv -> Type -> Compiler.Pass ()
+checkType _    TVar{}         = return ()
+checkType kenv (TCon tcon ts) = do
+  k <- maybe missing return $ M.lookup tcon kenv
+  unless (k == length ts) $ do
+    wrongKind k $ length ts
+  mapM_ (checkType kenv) ts
+ where
+  missing :: Compiler.Pass a
+  missing =
+    Compiler.typeError $ "Could not find type constructor: " ++ show tcon
+  wrongKind :: Kind -> Kind -> Compiler.Pass a
+  wrongKind expected actual = Compiler.typeError $ unlines
+    [ "Wrong kind for type: " ++ show tcon
+    , "Expected: " ++ fmtKind expected
+    , "Actual: " ++ fmtKind actual
+    ]
+  fmtKind :: Kind -> String
+  fmtKind k = concat $ "*" : replicate k " -> *"
+
+
+unravelAnnotation :: Annotation -> AnnRavel Type
+unravelAnnotation (AnnType t       ) = return t
 unravelAnnotation (AnnArrows ats rt) = do
   ats' <- mapM unravelAnnotation ats
-  rt' <- unravelAnnotation rt
+  rt'  <- unravelAnnotation rt
   return $ foldArrow (ats', rt')
-unravelAnnotation a =
-  Compiler.todo
-    $  "unravelAnnotation not yet able to handle non-trivial types: "
-    ++ show a
-
-checkTypeDefs :: [(TConId, TypeDef)] -> Compiler.Pass ()
-checkTypeDefs _ = return ()
+unravelAnnotation (AnnDCon dcon anns) = do
+  (kenv , denv ) <- ask
+  (dargs, dtype) <- maybe missing return $ M.lookup dcon denv
+  undefined
+ where
+  missing :: AnnRavel a
+  missing =
+    Compiler.typeError $ "Could not find data constructor: " ++ show dcon

--- a/src/IR/Types/Typechecking.hs
+++ b/src/IR/Types/Typechecking.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ViewPatterns #-}
+-- | Entry point to the type checking phase of the compiler.
 module IR.Types.Typechecking
   ( typecheckProgram
   ) where
@@ -10,6 +10,6 @@ import           IR.IR                          ( Annotations
                                                 )
 import           IR.Types.Inference             ( inferProgram )
 
--- | Typecheck a program. For now, we just use HM inference.
+-- | Type check an optionally annotated program.
 typecheckProgram :: Program Annotations -> Compiler.Pass (Program Type)
-typecheckProgram = inferProgram
+typecheckProgram = inferProgram -- for now, we just use HM inference

--- a/src/IR/Types/Typechecking.hs
+++ b/src/IR/Types/Typechecking.hs
@@ -3,105 +3,13 @@ module IR.Types.Typechecking
   ( typecheckProgram
   ) where
 
-import           IR.IR                          ( Annotation
-                                                , Annotations
-                                                , DConId
-                                                , Expr
+import qualified Common.Compiler               as Compiler
+import           IR.IR                          ( Annotations
                                                 , Program(..)
-                                                , TConId
                                                 , Type
-                                                , TypeDef(..)
-                                                , TypeVariant(..)
                                                 )
 import           IR.Types.Inference             ( inferProgram )
-import           IR.Types.Type                  ( Annotation
-                                                  ( AnnArrows
-                                                  , AnnDCon
-                                                  , AnnType
-                                                  )
-                                                , Type(TCon, TVar)
-                                                , foldArrow
-                                                , unAnnotations
-                                                )
-import qualified Common.Compiler               as Compiler
 
-import           Control.Monad.Reader           ( MonadReader(..)
-                                                , MonadTrans(..)
-                                                , ReaderT(..)
-                                                , unless
-                                                )
-import           Data.Bifunctor                 ( Bifunctor(..) )
-import qualified Data.Map                      as M
-
-type Kind = Int
-type KindEnv = M.Map TConId Kind
-type DConEnv = M.Map DConId ([Type], Type)
-type AnnRavel = ReaderT (KindEnv, DConEnv) Compiler.Pass
-
+-- | Typecheck a program. For now, we just use HM inference.
 typecheckProgram :: Program Annotations -> Compiler.Pass (Program Type)
-typecheckProgram p = do
-  let kenv = M.fromList $ map (second $ length . targs) $ typeDefs p
-  denv <- M.unions <$> mapM (checkTypeDef kenv) (typeDefs p)
-  defs <- (`runReaderT` (kenv, denv)) $ unravelAnns $ unwrapAnns $ programDefs p
-  inferProgram $ p { programDefs = defs }
- where
-  -- | Unwrap each 'Annotations' into a bare 'Annotation' list.
-  unwrapAnns :: [(a, Expr Annotations)] -> [(a, Expr [Annotation])]
-  unwrapAnns = fmap $ second $ fmap unAnnotations
-
-  -- | Unravel each 'Annotation' in the list into a 'Type', and check kindness.
-  unravelAnns :: [(a, Expr [Annotation])] -> AnnRavel [(a, Expr [Type])]
-  unravelAnns (unzip -> (bs, es)) = do
-    es'       <- mapM (mapM $ mapM unravelAnnotation) es
-    (kenv, _) <- ask
-    lift $ mapM_ (mapM $ mapM $ checkType kenv) es'
-    return $ zip bs es'
-
-checkTypeDef :: KindEnv -> (TConId, TypeDef) -> Compiler.Pass DConEnv
-checkTypeDef kenv (tcon, TypeDef { targs = tvs, variants = vs }) =
-  M.unions <$> mapM variant2env vs
- where
-  variant2env :: (DConId, TypeVariant) -> Compiler.Pass DConEnv
-  variant2env (dcon, VariantNamed ts) =
-    mapM_ (checkType kenv . snd) ts >> mkDConInfo dcon undefined
-  variant2env (dcon, VariantUnnamed ts) =
-    mapM_ (checkType kenv) ts >> mkDConInfo dcon ts
-
-  mkDConInfo :: DConId -> [Type] -> Compiler.Pass DConEnv
-  mkDConInfo dcon ts = return $ M.singleton dcon (ts, TCon tcon $ map TVar tvs)
-
-checkType :: KindEnv -> Type -> Compiler.Pass ()
-checkType _    TVar{}         = return ()
-checkType kenv (TCon tcon ts) = do
-  k <- maybe missing return $ M.lookup tcon kenv
-  unless (k == length ts) $ do
-    wrongKind k $ length ts
-  mapM_ (checkType kenv) ts
- where
-  missing :: Compiler.Pass a
-  missing =
-    Compiler.typeError $ "Could not find type constructor: " ++ show tcon
-  wrongKind :: Kind -> Kind -> Compiler.Pass a
-  wrongKind expected actual = Compiler.typeError $ unlines
-    [ "Wrong kind for type: " ++ show tcon
-    , "Expected: " ++ fmtKind expected
-    , "Actual: " ++ fmtKind actual
-    ]
-  fmtKind :: Kind -> String
-  fmtKind k = concat $ "*" : replicate k " -> *"
-
-
-unravelAnnotation :: Annotation -> AnnRavel Type
-unravelAnnotation (AnnType t       ) = return t
-unravelAnnotation (AnnArrows ats rt) = do
-  ats' <- mapM unravelAnnotation ats
-  rt'  <- unravelAnnotation rt
-  return $ foldArrow (ats', rt')
-unravelAnnotation (AnnDCon dcon anns) = do
-  (kenv , denv ) <- ask
-  (dargs, dtype) <- maybe missing return $ M.lookup dcon denv
-  undefined
- where
-  missing :: AnnRavel a
-  missing =
-    Compiler.typeError $ "Could not find data constructor: " ++ show dcon
+typecheckProgram = inferProgram

--- a/src/IR/Types/Unification.hs
+++ b/src/IR/Types/Unification.hs
@@ -72,9 +72,7 @@ import           Control.Unification.IntVar     ( IntBindingT
                                                 , evalIntBindingT
                                                 )
 
-import           Control.Monad                  ( forM
-                                                , zipWithM
-                                                )
+import           Control.Monad                  ( forM )
 import           Control.Monad.Except           ( ExceptT
                                                 , MonadError(..)
                                                 , runExceptT

--- a/src/IR/Types/Unification.hs
+++ b/src/IR/Types/Unification.hs
@@ -24,6 +24,7 @@ module IR.Types.Unification
   , HasFreeUVars(..)
   , InferM
   , MonadReader(..)
+  , asks
   , MonadError(..)
   , (=:=)
   , (<:=)
@@ -80,6 +81,7 @@ import           Control.Monad.Except           ( ExceptT
                                                 )
 import           Control.Monad.Reader           ( MonadReader(..)
                                                 , ReaderT(..)
+                                                , asks
                                                 )
 import           Control.Monad.Trans            ( MonadTrans(..) )
 import           Data.Function                  ( (&) )

--- a/src/IR/Types/Unification.hs
+++ b/src/IR/Types/Unification.hs
@@ -12,46 +12,60 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | Wrapper around the unification-fd library.
+
+Compared to normal types ('T.Type'), unification types ('Type') may contain
+unification variables, which only appear during the type inference process.
+
+This module provides a definition for unification types, an inference monad, as
+well as some pattern synonyms for the builtin types.
+-}
 module IR.Types.Unification
-  ( Type
+  ( -- * Unification types
+    Type
   , Scheme
   , pattern TVar
   , pattern TCon
-  , applyBindings
-  , freeze
-  , unfreeze
   , HasFreeUVars(..)
+
+  -- * The inference monad
   , InferM
-  , MonadReader(..)
-  , asks
-  , MonadError(..)
+  , runInfer
+  , fresh
+  , applyBindings
   , (=:=)
   , (<:=)
-  , fresh
-  , generalize
+  , unfreeze
+  , freeze
   , instantiate
-  , runInfer
-  , isTuple
-  , tuple
+  , generalize
+  , MonadReader(..)
+  , MonadError(..)
+  , asks
+
+  -- * Builtin types
   , pattern Hole
-  , pattern U8
-  , pattern I8
-  , pattern U32
-  , pattern I32
-  , pattern U64
-  , pattern I64
-  , pattern Time
-  , pattern List
-  , pattern Ref
-  , pattern Unit
   , pattern Arrow
   , foldArrow
   , unfoldArrow
+  , pattern Unit
+  , pattern Ref
+  , pattern List
+  , pattern Time
+  , pattern I64
+  , pattern U64
+  , pattern I32
+  , pattern U32
+  , pattern I16
+  , pattern U16
+  , pattern I8
+  , pattern U8
+  , tuple
   ) where
 
 import qualified Common.Compiler               as Compiler
 import           Common.Identifiers             ( HasFreeVars(..)
-                                                , Identifiable(..)
                                                 , TConId(..)
                                                 , TVarId(..)
                                                 , fromString
@@ -93,15 +107,23 @@ import           GHC.Generics                   ( Generic1 )
 deriving instance Ord IntVar
 deriving instance Unifiable []
 
-data TypeF a = TConF TConId [a] | TVarF TVarId
+-- | Base functor for the unification 'Type'.
+data TypeF a
+  = TConF TConId [a]  -- ^ type constructors
+  | TVarF TVarId      -- ^ (quantified) type variables
   deriving (Eq, Functor, Foldable, Traversable, Generic1, Unifiable)
 
+-- | A type that may also contain unification variables.
 type Type = UTerm TypeF IntVar
+
+-- | An explicitly quantified 'Type', which may contain unification variables.
 type Scheme = T.SchemeOf Type
 
+-- | Pattern synonym for 'Type' variables.
 pattern TVar :: TVarId -> Type
 pattern TVar v = UTerm (TVarF v)
 
+-- | Pattern synonym for 'Type' constructors.
 pattern TCon :: TConId -> [Type] -> Type
 pattern TCon tc ts = UTerm (TConF tc ts)
 
@@ -112,25 +134,6 @@ instance Show a => Show (TypeF a) where
   show (TConF tc   []    ) = show tc
   show (TConF tc   ts    ) = unwords (show tc : map show ts)
   show (TVarF v          ) = show v
-
--- | Promote a 'T.Type' to a 'Type'.
-unfreeze :: T.Type -> Type
-unfreeze (T.TCon tc ts) = UTerm $ TConF tc $ fmap unfreeze ts
-unfreeze (T.TVar v    ) = UTerm $ TVarF v
-
--- | Demote a 'Type' to a regular 'T.Type'.
---
--- Fails if the unification type contains more than just contructors and
--- variables.
-freeze :: Type -> InferM ctx T.Type
-freeze (TCon tc ts) = mapM freeze ts <&> T.TCon tc
-freeze (TVar v    ) = return $ T.TVar v
-freeze t =
-  throwError
-    $  Compiler.UnexpectedError
-    $  fromString
-    $  "Could not freeze: "
-    ++ show t
 
 -- | Catamorphism over unification types; useful for term rewriting.
 ucata :: Functor t => (v -> a) -> (t a -> a) -> UTerm t v -> a
@@ -179,20 +182,53 @@ instance HasFreeVars Type TVarId where
 type InferM ctx
   = ReaderT ctx (ExceptT Compiler.Error (IntBindingT TypeF Compiler.Pass))
 
+-- | Execute the 'InferM' inference monad.
+runInfer :: ctx -> InferM ctx a -> Compiler.Pass a
+runInfer ctx m =
+  m & (`runReaderT` ctx) & runExceptT & evalIntBindingT >>= \case
+    Left  err -> Compiler.throwError err
+    Right res -> return res
+
+-- | Create a fresh unification variable.
 fresh :: InferM ctx Type
 fresh = UVar <$> lift (lift freeVar)
 
-infix 4 =:=
-(=:=) :: Type -> Type -> InferM ctx ()
-s =:= t = lift $ s U.=:= t >> return ()
-
-infix 4 <:=
-(<:=) :: Type -> Type -> InferM ctx Bool
-s <:= t = lift $ s U.<:= t
-
+-- | Apply bindings from current monad so remaining bindings must be free.
 applyBindings :: Type -> InferM ctx Type
 applyBindings = lift . U.applyBindings
 
+-- | Unifies two types; fails if they cannot unify.
+(=:=) :: Type -> Type -> InferM ctx ()
+s =:= t = lift $ s U.=:= t >> return ()
+infix 4 =:=
+
+-- | Whether the LHS subsumes the RHS.
+(<:=) :: Type -> Type -> InferM ctx Bool
+s <:= t = lift $ s U.<:= t
+infix 4 <:=
+
+-- | Promote a 'T.Type' to a 'Type'.
+unfreeze :: T.Type -> Type
+unfreeze (T.TCon tc ts) = UTerm $ TConF tc $ fmap unfreeze ts
+unfreeze (T.TVar v    ) = UTerm $ TVarF v
+
+{- | Demote a 'Type' to a regular 'T.Type'.
+
+Fails if the unification type contains more than just contructors and
+variables.
+-}
+freeze :: Type -> InferM ctx T.Type
+freeze (TCon tc ts) = mapM freeze ts <&> T.TCon tc
+freeze (TVar v    ) = return $ T.TVar v
+freeze t =
+  throwError
+    $  Compiler.UnexpectedError
+    $  fromString
+    $  "Could not freeze: "
+    ++ show t
+
+-- | Instantiate a 'Scheme' by replacing all quantified type varibles with fresh
+-- unification variables
 instantiate :: Scheme -> InferM ctx Type
 instantiate (Forall (S.toList -> xs) _ uty) = do
   subs <- forM xs $ \v -> do
@@ -200,6 +236,8 @@ instantiate (Forall (S.toList -> xs) _ uty) = do
     return (Left v, fv)
   return $ substU (M.fromList subs) uty
 
+-- | Generalize a 'Type' by replacing all free unification variables with
+-- quantified type variables.
 generalize :: HasFreeUVars ctx => Type -> InferM ctx Scheme
 generalize uty = do
   uty'   <- applyBindings uty
@@ -216,68 +254,72 @@ generalize uty = do
   tvarNames :: [TVarId]
   tvarNames = map (("a" <>) . showId) [(1 :: Int) ..]
 
-runInfer :: ctx -> InferM ctx a -> Compiler.Pass a
-runInfer ctx m =
-  m & (`runReaderT` ctx) & runExceptT & evalIntBindingT >>= \case
-    Left  err -> Compiler.throwError err
-    Right res -> return res
+-- | A fresh, free type variable; may appear in type annotations.
+pattern Hole :: Type
+pattern Hole = UTerm (TVarF "_")
 
+-- | The type constructor for function arrows.
 pattern Arrow :: Type -> Type -> Type
 pattern Arrow a b = UTerm (TConF "->" [a, b])
 
+-- | Unfold an 'Arrow' 'Type' into a list of argument types and a return type.
 unfoldArrow :: Type -> ([Type], Type)
 unfoldArrow (Arrow a b) = let (as, rt) = unfoldArrow b in (a : as, rt)
 unfoldArrow t           = ([], t)
 
+-- | Fold a list of argument types and a return type into an 'Arrow' 'Type'.
 foldArrow :: ([Type], Type) -> Type
 foldArrow (a : as, rt) = a `Arrow` foldArrow (as, rt)
 foldArrow ([]    , t ) = t
 
-pattern Hole :: Type
-pattern Hole = UTerm (TVarF "_")
-
+-- | The builtin singleton 'Type', whose only data constructor is just @()@.
 pattern Unit :: Type
-pattern Unit = UTerm (TConF "()" [])
+pattern Unit = TCon "()" []
 
+-- | The builtin reference 'Type', created using @new@.
 pattern Ref :: Type -> Type
-pattern Ref a = UTerm (TConF "&" [a])
+pattern Ref a = TCon "&" [a]
 
+-- | The builtin list 'Type', created using list syntax, e.g., @[a, b]@.
 pattern List :: Type -> Type
-pattern List a = UTerm (TConF "[]" [a])
+pattern List a = TCon "[]" [a]
 
+-- | The builtin 64-bit timestamp 'Type'.
 pattern Time :: Type
-pattern Time = UTerm (TConF "Time" [])
+pattern Time = TCon "Time" []
 
+-- | Builtin 'Type' for signed 64-bit integers.
 pattern I64 :: Type
-pattern I64 = UTerm (TConF "Int64" [])
+pattern I64 = TCon "Int64" []
 
+-- | Builtin 'Type' for unsigned 64-bit integers.
 pattern U64 :: Type
-pattern U64 = UTerm (TConF "UInt64" [])
+pattern U64 = TCon "UInt64" []
 
+-- | Builtin 'Type' for signed 32-bit integers.
 pattern I32 :: Type
-pattern I32 = UTerm (TConF "Int32" [])
+pattern I32 = TCon "Int32" []
 
+-- | Builtin 'Type' for unsigned 32-bit integers.
 pattern U32 :: Type
-pattern U32 = UTerm (TConF "UInt32" [])
+pattern U32 = TCon "UInt32" []
 
+-- | Builtin 'Type' for signed 16-bit integers.
+pattern I16 :: Type
+pattern I16 = TCon "Int16" []
+
+-- | Builtin 'Type' for unsigned 16-bit integers.
+pattern U16 :: Type
+pattern U16 = TCon "UInt16" []
+
+-- | Builtin 'Type' for signed 8-bit integers.
 pattern I8 :: Type
-pattern I8 = UTerm (TConF "Int8" [])
+pattern I8 = TCon "Int8" []
 
+-- | Builtin 'Type' for unsigned 8-bit integers.
 pattern U8 :: Type
-pattern U8 = UTerm (TConF "UInt8" [])
+pattern U8 = TCon "UInt8" []
 
+-- | Construct a builtin tuple type out of a list of at least 2 types.
 tuple :: [Type] -> Type
-tuple ts = UTerm $ TConF (tupleId $ length ts) ts
-
--- | Tests whether a 'Type' is a tuple of some arity.
-isTuple :: Type -> Bool
-isTuple (UTerm (TConF n ts)) | length ts >= 2 = n == tupleId (length ts)
-isTuple _ = False
-
--- | Construct the name of the built-in tuple type of given arity.
---
--- Fails if arity is less than 2.
-tupleId :: (Integral i, Identifiable v) => i -> v
-tupleId i
-  | i >= 2    = fromString $ "(" ++ replicate (fromIntegral i - 1) ',' ++ ")"
-  | otherwise = error $ "Cannot create tuple of arity: " ++ show (toInteger i)
+tuple ts = UTerm $ TConF (T.tupleId $ length ts) ts

--- a/test/semant/Tests/TypeInferSpec.hs
+++ b/test/semant/Tests/TypeInferSpec.hs
@@ -130,7 +130,7 @@ spec = do
         addOne (x: a) = x + 1
       |]
     it "rejects a type annotation that over-generalizes a variable" $ do
-      pendingWith "FIXME"
+      pendingWith "some kind of generalization bug"
       typeErrors [here|
         addOne x = (x: a) + 1
       |]
@@ -418,6 +418,21 @@ spec = do
               MyRight b
 
             flattenEither x: MyEither (MyEither a b) (MyEither b a) -> MyEither a b =
+              match x
+                MyLeft  (MyRight a) = MyLeft a
+                MyLeft  (MyLeft b)  = MyRight b
+                MyRight (MyLeft a)  = MyLeft a
+                MyRight (MyRight b) = MyRight b
+            |]
+
+    it "typechecks a program with a specialized complicated pattern match" $ do
+      pendingWith "some kind of generalization bug"
+      typeChecks [here|
+            type MyEither a b
+              MyLeft a
+              MyRight b
+
+            flattenEither x: MyEither (MyEither a ()) (MyEither () a) -> MyEither a () =
               match x
                 MyLeft  (MyRight a) = MyLeft a
                 MyLeft  (MyLeft b)  = MyRight b


### PR DESCRIPTION
Follow up to #103, addressing remaining concerns:

- [x] actually unroll pattern annotations rather than discarding them
- [x] typecheck type definitions, i.e., check the kind of each type constructor
- [x] document everything lmao