### PR TITLE
add switch for spaghetti, update old comment

### DIFF
--- a/src/Common/Pretty.hs
+++ b/src/Common/Pretty.hs
@@ -61,7 +61,7 @@ spaghetti :: Dumpy t => t -> String
 spaghetti = renderString . layoutPretty opts . dumpy
   where opts = LayoutOptions { layoutPageWidth = Unbounded }
 
-{- | Lengthy Typeclass: print an ugly but parseable representation of the AST
+{- | Dumpy Typeclass: print an ugly but parseable representation of the AST
 
 * Translates from IR to Doc representation in one-to-one fashion
 * No simplifications 

--- a/src/IR.hs
+++ b/src/IR.hs
@@ -18,6 +18,7 @@ import           IR.Types                       ( fromAnnotations
                                                 , typecheckProgram
                                                 )
 
+import           Common.Pretty                  ( spaghetti )
 import           Control.Monad                  ( (>=>)
                                                 , when
                                                 )
@@ -33,6 +34,7 @@ data Mode
   | DumpIR
   | DumpIRAnnotated
   | DumpIRTyped
+  | DumpIRTypedUgly
   | DumpIRLifted
   | DumpIRFinal
   deriving (Eq, Show)
@@ -59,6 +61,11 @@ options =
            ["dump-ir-typed"]
            (NoArg $ setMode DumpIRTyped)
            "Print the fully-typed IR after type inference"
+  , Option
+    ""
+    ["dump-ir-typed-ugly"]
+    (NoArg $ setMode DumpIRTypedUgly)
+    "Ugly-Print the fully-typed IR after type inference"
   , Option ""
            ["dump-ir-lifted"]
            (NoArg $ setMode DumpIRLifted)
@@ -85,6 +92,7 @@ typecheck opt p = do
   when (mode opt == DumpIRAnnotated) $ dump $ fmap fromAnnotations p
   p <- typecheckProgram p
   when (mode opt == DumpIRTyped) $ dump p
+  when (mode opt == DumpIRTypedUgly) $ (throwError . Dump . show . spaghetti) p
   return p
 
 -- | IR transformations to prepare for codegen.


### PR DESCRIPTION
Adds a compiler switch so the user can print IR after type inference with all type annotations visible. This is an ugly/lispy output but it can be helpful for development.