### PR TITLE
Add list syntax

### DIFF
--- a/regression-tests/tests/list3-new-syntax.ssl
+++ b/regression-tests/tests/list3-new-syntax.ssl
@@ -1,0 +1,18 @@
+type String
+  Cons Int String
+  Nil
+
+puts cout s =
+  match s
+    Cons c ss =
+      after 1, cout <- c
+      wait cout
+//      puts cout ss
+    Nil = ()
+
+main cin cout =
+ let hello = [72, 101, 10]
+ puts cout hello
+
+
+ 


### PR DESCRIPTION
In order to add our desired list syntax to SSLANG, we're replicating existing test cases and replacing old list syntax with new list syntax. I'm currently working on making a new test "list3-new-syntax.ssl" compile by understanding the errors and editing the parser. This test is a copy of "list3.ssl"