### PR TITLE
Add desugar stubs for strings and lists

### DIFF
--- a/src/Front.hs
+++ b/src/Front.hs
@@ -12,6 +12,8 @@ import           Common.Default                 ( Default(..) )
 
 import qualified Front.Ast                     as A
 
+import           Front.DesugarLists             ( desugarLists )
+import           Front.DesugarStrings           ( desugarStrings )
 import           Front.ParseOperators           ( parseOperators )
 import           Front.Parser                   ( parseProgram )
 import qualified Front.Pattern                 as Pattern
@@ -77,8 +79,11 @@ parseAst opt src = do
   astP <- parseOperators ast
   when (optMode opt == DumpAstParsed) $ dump $ show $ pretty astP
 
+  astDS <- desugarStrings astP
+  astDL <- desugarLists astDS
+
   -- TODO: other desugaring
-  Pattern.checkAnomaly astP
+  Pattern.checkAnomaly astDL
   astD <- Pattern.desugarProgram astP
 
   when (optMode opt == DumpAstFinal) $ dump $ show $ pretty astD

--- a/src/Front/DesugarLists.hs
+++ b/src/Front/DesugarLists.hs
@@ -1,6 +1,6 @@
--- | Desugar String Literal nodes into ListExpr nodes
-module Front.DesugarStrings
-  ( desugarStrings
+-- | Desugar ListExpr nodes into App nodes
+module Front.DesugarLists
+  ( desugarLists
   ) where
 
 import qualified Common.Compiler               as Compiler
@@ -10,9 +10,9 @@ import           Front.Ast                      ( Definition(..)
                                                 , TopDef(..)
                                                 )
 
--- | Desugar String Literal nodes inside of an AST 'Program'.
-desugarStrings :: Program -> Compiler.Pass Program
-desugarStrings (Program decls) = return $ Program $ desugarTop <$> decls
+-- | Desugar ListExpr nodes inside of an AST 'Program'.
+desugarLists :: Program -> Compiler.Pass Program
+desugarLists (Program decls) = return $ Program $ desugarTop <$> decls
  where
   desugarTop (TopDef d) = TopDef $ desugarDef d
   desugarTop t          = t
@@ -20,7 +20,10 @@ desugarStrings (Program decls) = return $ Program $ desugarTop <$> decls
   desugarDef (DefFn v bs t e) = DefFn v bs t $ desugarExpr e
   desugarDef (DefPat b e    ) = DefPat b $ desugarExpr e
 
--- | Transform a node of type LitString into a node of type ListExpr
--- For ex, (Lit (LitString "abc")) turns into (ListExpr [97, 98, 99])
+-- | Transform a node of type ListExpr into a node of type App 
+-- For ex, (ListExpr [1, 2, 3]) turns into
+-- App (App (Id "Cons") (Lit (LitInt 1) )) 
+--     (App (App (Id "Cons") (Lit (LitInt 2))) 
+--          (App (App (Id "Cons") (Lit (LitInt 3))) (id "Nil")))
 desugarExpr :: Expr -> Expr
 desugarExpr e = e -- TODO: actually implement transformation

--- a/src/Front/DesugarStrings.hs
+++ b/src/Front/DesugarStrings.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Transform String Literal nodes into App nodes
+module Front.DesugarStrings
+  ( desugarStrings
+  ) where
+
+import qualified Common.Compiler               as Compiler
+import           Common.Identifiers
+
+import           Front.Ast                      ( Definition(..)
+                                                , Expr(..)
+                                                , Fixity(..)
+                                                , OpRegion(..)
+                                                , Program(..)
+                                                , TopDef(..)
+                                                )
+
+import           Data.Bifunctor                 ( Bifunctor(..) )
+import qualified Data.Map.Strict               as Map
+
+data Stack = BOS
+           | Stack Stack Expr Identifier
+
+-- FIXME: These should be defined and included in the standard library
+-- | Default fixity of operators.
+defaultOps :: [Fixity]
+defaultOps =
+  [ Infixl 4 "=="
+  , Infixl 4 "!="
+  , Infixl 4 "<="
+  , Infixl 4 ">="
+  , Infixl 4 "<"
+  , Infixl 4 ">"
+  , Infixl 6 "+"
+  , Infixl 6 "-"
+  , Infixl 8 "*"
+  , Infixl 8 "/"
+  , Infixl 8 "%"
+  , Infixr 8 "^"
+  ]
+
+-- | Desugar String Literal nodes inside of an AST 'Program'.
+desugarStrings :: Program -> Compiler.Pass Program
+desugarStrings (Program decls) = return $ Program $ map (desugarTop ops) decls
+ where
+  ops = defaultOps
+  desugarTop fs (TopDef d) = TopDef $ desugarDef fs d
+  desugarTop _  t          = t
+
+  desugarDef fs (DefFn v bs t e) = DefFn v bs t $ desugarExpr fs e
+  desugarDef fs (DefPat b e    ) = DefPat b $ desugarExpr fs e
+
+-- | Transform nodes of type LitString into nodes of type App 
+--   according to the given Fixity specifications
+desugarExpr :: [Fixity] -> Expr -> Expr
+desugarExpr fixity = rw
+ where
+  rw r@(OpRegion _ _) = let OpRegion e r' = rewrite rw r in step BOS e r'
+  rw e                = rewrite rw e
+
+  defaultPrec = (18, 17)
+  opMap       = Map.fromList $ map fixToPair fixity
+
+  fixToPair (Infixl prec op) = (op, (prec * 2, prec * 2 - 1))
+  fixToPair (Infixr prec op) = (op, (prec * 2, prec * 2 + 1))
+
+  step :: Stack -> Expr -> OpRegion -> Expr
+  step BOS             e  EOR               = e
+  step BOS             e1 (NextOp op e2 ts) = shift BOS e1 op e2 ts
+  step (Stack s e1 op) e2 EOR               = reduce s e1 op e2 EOR
+  step s0@(Stack s1 e1 op1) e2 t0@(NextOp op2 e3 t1)
+    | op1 `shouldShift` op2 = shift s0 e2 op2 e3 t1
+    | otherwise             = reduce s1 e1 op1 e2 t0
+
+  shift, reduce :: Stack -> Expr -> Identifier -> Expr -> OpRegion -> Expr
+  shift s e1 op e2 ts = step (Stack s e1 op) e2 ts
+  reduce s e1 op e2 ts = step s (Apply (Apply (Id op) e1) e2) ts
+
+  shouldShift :: Identifier -> Identifier -> Bool
+  shouldShift opl opr = pl < pr
+   where
+    pl   = fst prel
+    pr   = snd prer
+    prel = Map.findWithDefault defaultPrec opl opMap
+    prer = Map.findWithDefault defaultPrec opr opMap
+
+  -- | Rewriter for expressions. ('Expr' is almost a functor, except its kind is
+  -- @*@; functors must be of kind @* -> *@.)
+  rewrite :: (Expr -> Expr) -> Expr -> Expr
+  rewrite f (Apply    e1 e2) = Apply (f e1) (f e2)
+  rewrite f (OpRegion e  r ) = OpRegion (f e) (h r)
+   where
+    h EOR               = EOR
+    h (NextOp op e' r') = NextOp op (f e') (h r')
+  rewrite f (Let d b) = Let (map g d) $ f b
+   where
+    g (DefFn v bs t e) = DefFn v bs t $ f e
+    g (DefPat p e    ) = DefPat p $ f e
+  rewrite f (While e1 e2     ) = While (f e1) (f e2)
+  rewrite f (Loop e          ) = Loop (f e)
+  rewrite f (Par  e          ) = Par $ map f e
+  rewrite f (Wait e          ) = Wait $ map f e
+  rewrite f (IfElse e1 e2 e3 ) = IfElse (f e1) (f e2) (f e3)
+  rewrite f (After  e1 p  e2 ) = After (f e1) p (f e2)
+  rewrite f (Assign     p  e ) = Assign p (f e)
+  rewrite f (Constraint e  t ) = Constraint (f e) t
+  rewrite f (Seq        e1 e2) = Seq (f e1) (f e2)
+  rewrite f (Lambda     ps b ) = Lambda ps (f b)
+  rewrite f (Match      s  as) = Match (f s) $ map (second f) as
+  rewrite _ e                  = e


### PR DESCRIPTION
This PR adds two stubbed-out passes to the front end of the compiler,
1) desugarStrings // meant to change LitString --> ListExpr
2) desugarLists // meant to change ListExpr --> App

for @as0501  and @max-acebal  to work on respectively.