### PR TITLE
Allow recursive patterns in the IR

### DIFF
--- a/src/Codegen/Codegen.hs
+++ b/src/Codegen/Codegen.hs
@@ -657,7 +657,7 @@ genExpr (I.Match s as t) = do
     withAltScope label (I.AltLit l) m = do
       blk <- m
       return ([citem|case $exp:(genLiteralRaw l):;|], mkBlk label blk)
-    withAltScope label (I.AltDefault b) m = do
+    withAltScope label (I.AltBinder b) m = do
       blk <- withBindings [(b, scrut)] m
       addBinding b scrut
       return ([citem|default:;|], mkBlk label blk)

--- a/src/Codegen/Codegen.hs
+++ b/src/Codegen/Codegen.hs
@@ -651,9 +651,7 @@ genExpr (I.Match s as t) = do
       destruct <- getsDCon dconDestruct dcon
       cas      <- getsDCon dconCase dcon
       let fieldBinds =
-            zipWith (\field i -> (getAltDefault field, destruct i scrut)) fields [0 ..]
-            where getAltDefault (I.AltDefault b) = b
-                  getAltDefault _ = Nothing
+            zipWith (\field i -> (I.getAltDefault field, destruct i scrut)) fields [0 ..]
       blk <- withBindings fieldBinds m
       return ([citem|case $exp:cas:;|], mkBlk label blk)
     withAltScope label (I.AltLit l) m = do

--- a/src/Codegen/Codegen.hs
+++ b/src/Codegen/Codegen.hs
@@ -651,7 +651,9 @@ genExpr (I.Match s as t) = do
       destruct <- getsDCon dconDestruct dcon
       cas      <- getsDCon dconCase dcon
       let fieldBinds =
-            zipWith (\field i -> (field, destruct i scrut)) fields [0 ..]
+            zipWith (\field i -> (getAltDefault field, destruct i scrut)) fields [0 ..]
+            where getAltDefault (I.AltDefault b) = b
+                  getAltDefault _ = Nothing
       blk <- withBindings fieldBinds m
       return ([citem|case $exp:cas:;|], mkBlk label blk)
     withAltScope label (I.AltLit l) m = do

--- a/src/IR/IR.hs
+++ b/src/IR/IR.hs
@@ -222,7 +222,7 @@ data Expr t
 
 -- | An alternative in a pattern-match.
 data Alt
-  = AltData DConId [Binder]
+  = AltData DConId [Alt]
   -- ^ @AltData d vs@ matches data constructor @d@, and names dcon members @vs@.
   | AltLit Literal
   -- ^ @AltLit l@ matches against literal @l@, producing expression @e@.
@@ -320,7 +320,7 @@ instance HasFreeVars (Expr t) VarId where
    where
     freeAltVars :: (Alt, Expr t) -> S.Set VarId
     freeAltVars (a, e) = freeVars e \\ altBinders a
-    altBinders (AltData _ bs                 ) = S.fromList $ catMaybes bs
+    altBinders (AltData _ bs                 ) = S.unions $ map altBinders bs
     altBinders (AltLit     _                 ) = S.empty
     altBinders (AltDefault (maybeToList -> v)) = S.fromList v
 

--- a/src/IR/IR.hs
+++ b/src/IR/IR.hs
@@ -30,6 +30,7 @@ module IR.IR
   , foldApp
   , unfoldApp
   , isValue
+  , getAltDefault
   ) where
 import           Common.Identifiers             ( Binder
                                                 , CSym(..)
@@ -306,6 +307,12 @@ isValue Data{}   = True
 isValue Lit{}    = True
 isValue Lambda{} = True
 isValue _        = False
+
+-- £ü Retrieve binder from Alt, assuming it is AltDefault.
+getAltDefault :: Alt -> Binder
+getAltDefault (AltDefault b) = b
+getAltDefault _ = error 
+  "Compiler Error: Should not have recursive patterns here"
 
 instance HasFreeVars (Expr t) VarId where
   freeVars (Var v _)                        = S.singleton v

--- a/src/IR/InsertRefCounting.hs
+++ b/src/IR/InsertRefCounting.hs
@@ -331,10 +331,8 @@ insertAlt (I.AltDefault v      , e   ) = (I.AltDefault v, ) <$> insertExpr e
 insertAlt (I.AltLit     l      , e   ) = (I.AltLit l, ) <$> insertExpr e
 insertAlt (I.AltData dcon binds, body) = do
   body' <- insertExpr body
-  return (I.AltData dcon binds, foldr (dropDupLet . getAltDefault) body' binds)
+  return (I.AltData dcon binds, foldr (dropDupLet . I.getAltDefault) body' binds)
  where
-  getAltDefault (I.AltDefault b) = b
-  getAltDefault _ = Nothing
   dropDupLet Nothing  e = e
   dropDupLet (Just v) e = makeDrop
     varExpr

--- a/src/IR/InsertRefCounting.hs
+++ b/src/IR/InsertRefCounting.hs
@@ -331,8 +331,10 @@ insertAlt (I.AltDefault v      , e   ) = (I.AltDefault v, ) <$> insertExpr e
 insertAlt (I.AltLit     l      , e   ) = (I.AltLit l, ) <$> insertExpr e
 insertAlt (I.AltData dcon binds, body) = do
   body' <- insertExpr body
-  return (I.AltData dcon binds, foldr dropDupLet body' binds)
+  return (I.AltData dcon binds, foldr (dropDupLet . getAltDefault) body' binds)
  where
+  getAltDefault (I.AltDefault b) = b
+  getAltDefault _ = Nothing
   dropDupLet Nothing  e = e
   dropDupLet (Just v) e = makeDrop
     varExpr

--- a/src/IR/InsertRefCounting.hs
+++ b/src/IR/InsertRefCounting.hs
@@ -327,7 +327,7 @@ match v
 @
 -}
 insertAlt :: (I.Alt, I.Expr I.Type) -> Fresh (I.Alt, I.Expr I.Type)
-insertAlt (I.AltDefault v      , e   ) = (I.AltDefault v, ) <$> insertExpr e
+insertAlt (I.AltBinder v      , e   ) = (I.AltBinder v, ) <$> insertExpr e
 insertAlt (I.AltLit     l      , e   ) = (I.AltLit l, ) <$> insertExpr e
 insertAlt (I.AltData dcon binds, body) = do
   body' <- insertExpr body

--- a/src/IR/LambdaLift.hs
+++ b/src/IR/LambdaLift.hs
@@ -27,7 +27,8 @@ import           Control.Monad.State.Lazy       ( MonadState
 import           Data.Bifunctor                 ( first )
 import           Data.List                      ( intersperse )
 import qualified Data.Map                      as M
-import           Data.Maybe                     ( catMaybes )
+import           Data.Maybe                     ( catMaybes 
+                                                , mapMaybe)
 import qualified Data.Set                      as S
 
 -- | Lifting Environment
@@ -255,7 +256,9 @@ liftLambdasInArm (I.AltDefault b, arm) = do
   return (I.AltDefault b, liftedArm)
 liftLambdasInArm (I.AltData d bs, arm) = do
   (liftedArm, armFrees) <- descend Nothing $ do
-    mapM_ addCurrentScope (catMaybes bs)
+    mapM_ addCurrentScope (mapMaybe getAltDefault bs)
     liftLambdas arm
   modify $ \st -> st { freeTypes = armFrees }
   return (I.AltData d bs, liftedArm)
+  where getAltDefault (I.AltDefault b) = b
+        getAltDefault _ = Nothing

--- a/src/IR/LambdaLift.hs
+++ b/src/IR/LambdaLift.hs
@@ -27,8 +27,9 @@ import           Control.Monad.State.Lazy       ( MonadState
 import           Data.Bifunctor                 ( first )
 import           Data.List                      ( intersperse )
 import qualified Data.Map                      as M
-import           Data.Maybe                     ( catMaybes 
-                                                , mapMaybe)
+import           Data.Maybe                     ( catMaybes
+                                                , mapMaybe
+                                                )
 import qualified Data.Set                      as S
 
 -- | Lifting Environment
@@ -259,4 +260,4 @@ liftLambdasInArm (I.AltData d bs, arm) = do
     mapM_ addCurrentScope (mapMaybe I.getAltDefault bs)
     liftLambdas arm
   modify $ \st -> st { freeTypes = armFrees }
-  return (I.AltData d bs, liftedArm)   
+  return (I.AltData d bs, liftedArm)

--- a/src/IR/LambdaLift.hs
+++ b/src/IR/LambdaLift.hs
@@ -249,12 +249,12 @@ liftLambdasInArm (I.AltLit l, arm) = do
   (liftedArm, armFrees) <- descend Nothing $ liftLambdas arm
   modify $ \st -> st { freeTypes = armFrees }
   return (I.AltLit l, liftedArm)
-liftLambdasInArm (I.AltDefault b, arm) = do
+liftLambdasInArm (I.AltBinder b, arm) = do
   (liftedArm, armFrees) <- descend Nothing $ do
     forM_ b addCurrentScope
     liftLambdas arm
   modify $ \st -> st { freeTypes = armFrees }
-  return (I.AltDefault b, liftedArm)
+  return (I.AltBinder b, liftedArm)
 liftLambdasInArm (I.AltData d bs, arm) = do
   (liftedArm, armFrees) <- descend Nothing $ do
     mapM_ addCurrentScope (mapMaybe I.getAltDefault bs)

--- a/src/IR/LambdaLift.hs
+++ b/src/IR/LambdaLift.hs
@@ -256,9 +256,7 @@ liftLambdasInArm (I.AltDefault b, arm) = do
   return (I.AltDefault b, liftedArm)
 liftLambdasInArm (I.AltData d bs, arm) = do
   (liftedArm, armFrees) <- descend Nothing $ do
-    mapM_ addCurrentScope (mapMaybe getAltDefault bs)
+    mapM_ addCurrentScope (mapMaybe I.getAltDefault bs)
     liftLambdas arm
   modify $ \st -> st { freeTypes = armFrees }
-  return (I.AltData d bs, liftedArm)
-  where getAltDefault (I.AltDefault b) = b
-        getAltDefault _ = Nothing
+  return (I.AltData d bs, liftedArm)   

--- a/src/IR/LowerAst.hs
+++ b/src/IR/LowerAst.hs
@@ -150,7 +150,7 @@ lowerExpr (A.Seq l r) = do
 lowerExpr A.Break          = return $ I.Prim I.Break [] untyped
 lowerExpr (A.IfElse c t e) = do
   c' <- lowerExpr c
-  t' <- (I.AltDefault Nothing, ) <$> lowerExpr t
+  t' <- (I.AltBinder Nothing, ) <$> lowerExpr t
   e' <- (I.AltLit (I.LitIntegral 0), ) <$> lowerExpr e
   return $ I.Match c' [e', t'] untyped
 lowerExpr (A.CQuote s) = return $ I.Prim (I.CQuote $ fromString s) [] untyped
@@ -167,8 +167,8 @@ lowerExpr (A.ListExpr _) =
 
 -- | Lower an A.Pat into an I.Alt
 lowerPatAlt :: A.Pat -> Compiler.Pass I.Alt
-lowerPatAlt A.PatWildcard = return $ I.AltDefault Nothing
-lowerPatAlt (A.PatId i) | isVar i   = return $ I.AltDefault (Just $ I.VarId i)
+lowerPatAlt A.PatWildcard = return $ I.AltBinder Nothing
+lowerPatAlt (A.PatId i) | isVar i   = return $ I.AltBinder (Just $ I.VarId i)
                         | otherwise = return $ I.AltData (I.DConId i) []
 lowerPatAlt (A.PatLit l) = I.AltLit <$> lowerLit l
 lowerPatAlt (A.PatTup ps) =

--- a/src/IR/LowerAst.hs
+++ b/src/IR/LowerAst.hs
@@ -172,9 +172,9 @@ lowerPatAlt (A.PatId i) | isVar i   = return $ I.AltDefault (Just $ I.VarId i)
                         | otherwise = return $ I.AltData (I.DConId i) []
 lowerPatAlt (A.PatLit l) = I.AltLit <$> lowerLit l
 lowerPatAlt (A.PatTup ps) =
-  I.AltData (I.tupleId $ length ps) <$> mapM lowerPatBinder ps
+  I.AltData (I.tupleId $ length ps) <$> mapM lowerPatAlt ps
 lowerPatAlt p@(A.PatApp _) = case A.collectPApp p of
-  (A.PatId i, ps) | isCons i -> I.AltData (fromId i) <$> mapM lowerPatBinder ps
+  (A.PatId i, ps) | isCons i -> I.AltData (fromId i) <$> mapM lowerPatAlt ps
   _ -> Compiler.unexpected "lowerPatAlt: app head should be a data constructor"
 lowerPatAlt (A.PatAnn _ p) = lowerPatAlt p
 lowerPatAlt (A.PatAs _ _) =

--- a/src/IR/Types/Inference.hs
+++ b/src/IR/Types/Inference.hs
@@ -221,7 +221,7 @@ inferAlt t (AltLit l) = do
   t' <- U.instantiate =<< inferLit l
   t =:= t'
   return []
-inferAlt t (AltDefault b) = return [(b, T.forall [] t)]
+inferAlt t (AltBinder b) = return [(b, T.forall [] t)]
 
 -- | Type inference rules for primitives of a given arity.
 inferPrim :: Int -> Primitive -> Infer U.Scheme

--- a/src/IR/Types/Inference.hs
+++ b/src/IR/Types/Inference.hs
@@ -216,8 +216,7 @@ inferAlt t (AltData d as) = do
       , "Expected: " <> show (length ats)
       , "Got: " <> show (length as)
       ]
-  let as' = map AltDefault as -- TODO: remove for nested patterns, just use as
-  concat <$> zipWithM inferAlt ats as'
+  concat <$> zipWithM inferAlt ats as
 inferAlt t (AltLit l) = do
   t' <- U.instantiate =<< inferLit l
   t =:= t'


### PR DESCRIPTION
This PR adds recursive pattern matching in the IR and also fixes the later passes that are affected by this change.  All passes after type checking will assume that the patterns are non-recursive even though recursive patterns are expressible.

Recursive patterns in the IR are a prerequisite for moving the desugaring and exhaustion-checking to the IR, i.e., after type checking. 