### PR TITLE
Desugar topDef

### DIFF
--- a/src/Front/Pattern/Desugar.hs
+++ b/src/Front/Pattern/Desugar.hs
@@ -92,10 +92,11 @@ desugarDefs = mapM desugarDef
 
 -- WARN: only body is desugared
 -- toplevel DefFn is desugared
+-- WARN: fail building until tuple implementation is merged
 desugarDef :: A.Definition -> DesugarFn A.Definition
 desugarDef (A.DefFn i ps t e) = do
   ps' <- mapM genNewPat ps
-  e'  <- desugarExpr $ A.Match (A.Tuple ps') [(A.PatTup ps, e)] -- will work after Tuple is added to Expr
+  e'  <- desugarExpr $ A.Match (A.Tuple ps') [(A.PatTup ps, e)] 
   return $ A.DefFn i ps' t e'
   where
     genNewPat :: A.Pat -> DesugarFn A.Pat

--- a/src/Front/Pattern/Desugar.hs
+++ b/src/Front/Pattern/Desugar.hs
@@ -70,16 +70,6 @@ desugarProgram (A.Program defs) = runDesugarFn
   tds = mapMaybe A.getTopTypeDef defs
   ctx = buildCtx tds
 
-splitGroup :: [A.TopDef] -> [[A.TopDef]]
-splitGroup []             = []
-splitGroup lst@(td : tds) = curr : splitGroup rest
- where
-  (curr, rest) = case td of
-    A.TopDef (A.DefFn i _ _ _) -> span (`sameId` i) lst
-    _                          -> ([td], tds)
-  sameId (A.TopDef (A.DefFn i' _ _ _)) = (i' ==)
-  sameId _                             = const False
-
 desugarTopDefs :: [A.TopDef] -> DesugarFn [A.TopDef]
 desugarTopDefs = mapM desugarTopDef
 

--- a/src/Front/Pattern/Desugar.hs
+++ b/src/Front/Pattern/Desugar.hs
@@ -11,7 +11,7 @@ import           Common.Compiler                ( Error(..)
 import           Common.Identifiers             ( Identifier(..)
                                                 , isCons
                                                 )
-import           Control.Monad                  ( replicateM )
+import           Control.Monad                  ( replicateM)
 import           Control.Monad.State.Lazy       ( MonadState
                                                 , StateT(..)
                                                 , evalStateT
@@ -70,11 +70,47 @@ desugarProgram (A.Program defs) = runDesugarFn
   tds = mapMaybe A.getTopTypeDef defs
   ctx = buildCtx tds
 
+splitGroup :: [A.TopDef] -> [[A.TopDef]]
+splitGroup [] = []
+splitGroup (td:tds) = case td of
+  A.TopDef (A.DefFn i _ _ _) -> curr : splitGroup rest
+    where
+      (curr, rest) = span (helper i) tds
+      helper :: Identifier -> A.TopDef -> Bool
+      helper i' (A.TopDef (A.DefFn i'' _ _ _)) = i' == i''
+      helper _ _ = False
+  _ -> [td] : splitGroup tds
+
+
+
 desugarTopDefs :: [A.TopDef] -> DesugarFn [A.TopDef]
-desugarTopDefs = mapM desugarTopDef
+desugarTopDefs tds = mapM desugarTopDef groups
  where
-  desugarTopDef (A.TopDef d) = A.TopDef <$> desugarDef d
-  desugarTopDef d            = return d
+  desugarTopDef :: [A.TopDef] -> DesugarFn A.TopDef
+  desugarTopDef []  = error "can't happen"
+  desugarTopDef [d] = return d
+  desugarTopDef tdfds = A.TopDef <$> mergeDefFn (map myJoin tdfds)
+  groups = splitGroup tds
+  myJoin td = case td of
+    A.TopDef d -> d
+    _ -> error "can't happen"
+  mergeDefFn :: [A.Definition] -> DesugarFn A.Definition
+  mergeDefFn ds = return $ A.DefFn i' [A.PatId $ Identifier "x"] t' e'
+    where
+      getDefFnIdentifier (A.DefFn i'' _ _ _) = i''
+      getDefFnIdentifier _ = error "can't happen"
+      getDefFnType (A.DefFn _ _ t'' _) = t''
+      getDefFnType _ = error "can't happen"
+      getDefFnExpr (A.DefFn _ _ _ e) = e
+      getDefFnExpr _ = error "can't happen"
+      getDefFnPat (A.DefFn _ ps _ _) = A.PatTup ps
+      getDefFnPat _ = error "can't happen"
+      mergeExpr :: [A.Pat] -> [A.Expr] -> A.Expr
+      mergeExpr ps es = A.Match (A.Id $ Identifier "x") $ zip ps es
+      i' = getDefFnIdentifier $ head ds
+      t' = getDefFnType $ head ds
+      e' = mergeExpr (map getDefFnPat ds) (map getDefFnExpr ds)
+
 
 desugarDefs :: [A.Definition] -> DesugarFn [A.Definition]
 desugarDefs = mapM desugarDef

--- a/src/Front/Pattern/Desugar.hs
+++ b/src/Front/Pattern/Desugar.hs
@@ -84,6 +84,11 @@ desugarDefs = mapM desugarDef
 -- toplevel DefFn is desugared
 -- WARN: fail building until tuple implementation is merged
 desugarDef :: A.Definition -> DesugarFn A.Definition
+desugarDef def@(A.DefFn _ [] _ _) = return def
+desugarDef (A.DefFn i [p] t e) = do
+  newId <- freshVar
+  e' <- desugarExpr $ A.Match (A.Id newId) [(p, e)]
+  return $ A.DefFn i [A.PatId newId] t e'
 desugarDef (A.DefFn i ps t e) = do
   newIdsPats <- mapM genNewIdNewPat ps
   let (psI,ps') = unzip newIdsPats

--- a/src/Front/Pattern/Desugar.hs
+++ b/src/Front/Pattern/Desugar.hs
@@ -85,17 +85,15 @@ desugarDefs = mapM desugarDef
 -- WARN: fail building until tuple implementation is merged
 desugarDef :: A.Definition -> DesugarFn A.Definition
 desugarDef (A.DefFn i ps t e) = do
-  psI <- mapM genNewId ps
-  ps' <- mapM genNewPat ps
+  newIdsPats <- mapM genNewIdNewPat ps
+  let (psI,ps') = unzip newIdsPats
   e'  <- desugarExpr $ A.Match (A.Tuple psI) [(A.PatTup ps, e)]
   return $ A.DefFn i ps' t e'
  where
-  genNewId :: A.Pat -> DesugarFn A.Expr
-  genNewId _ = do
-    A.Id <$> freshVar
-  genNewPat :: A.Pat -> DesugarFn A.Pat
-  genNewPat _ = do
-    A.PatId <$> freshVar
+  genNewIdNewPat :: A.Pat -> DesugarFn (A.Expr,A.Pat)
+  genNewIdNewPat _ = do
+    newVar <- freshVar
+    return (A.Id newVar, A.PatId newVar)
 desugarDef (A.DefPat p e) = A.DefPat p <$> desugarExpr e
 
 desugarExprs :: [A.Expr] -> DesugarFn [A.Expr]

--- a/src/Front/Pattern/Desugar.hs
+++ b/src/Front/Pattern/Desugar.hs
@@ -85,7 +85,7 @@ desugarTopDefs = mapM desugarTopDef
 
 desugarTopDef :: A.TopDef -> DesugarFn A.TopDef
 desugarTopDef (A.TopDef d) = A.TopDef <$> desugarDef d
-desugarTopDef d = return d
+desugarTopDef d            = return d
 
 desugarDefs :: [A.Definition] -> DesugarFn [A.Definition]
 desugarDefs = mapM desugarDef
@@ -96,13 +96,13 @@ desugarDefs = mapM desugarDef
 desugarDef :: A.Definition -> DesugarFn A.Definition
 desugarDef (A.DefFn i ps t e) = do
   ps' <- mapM genNewPat ps
-  e'  <- desugarExpr $ A.Match (A.Tuple ps') [(A.PatTup ps, e)] 
+  e'  <- desugarExpr $ A.Match (A.Tuple ps') [(A.PatTup ps, e)]
   return $ A.DefFn i ps' t e'
-  where
-    genNewPat :: A.Pat -> DesugarFn A.Pat
-    genNewPat _ = do
-      A.PatId <$> freshVar
-desugarDef (A.DefPat p e    ) = A.DefPat p <$> desugarExpr e
+ where
+  genNewPat :: A.Pat -> DesugarFn A.Pat
+  genNewPat _ = do
+    A.PatId <$> freshVar
+desugarDef (A.DefPat p e) = A.DefPat p <$> desugarExpr e
 
 desugarExprs :: [A.Expr] -> DesugarFn [A.Expr]
 desugarExprs = mapM desugarExpr

--- a/src/Front/Pattern/Desugar.hs
+++ b/src/Front/Pattern/Desugar.hs
@@ -75,7 +75,7 @@ splitGroup [] = []
 splitGroup (td:tds) = case td of
   A.TopDef (A.DefFn i _ _ _) -> curr : splitGroup rest
     where
-      (curr, rest) = span (helper i) tds
+      (curr, rest) = span (helper i) (td:tds)
       helper :: Identifier -> A.TopDef -> Bool
       helper i' (A.TopDef (A.DefFn i'' _ _ _)) = i' == i''
       helper _ _ = False


### PR DESCRIPTION
With this PR, the top level function definitions with pattern matching will be transformed into a equivalent one starting with a match in function body

> - Top level function definition with no pattern:
> 
> ```
> f  = expr
> ```
> 
> will remain unchanged


> - Top level function definition with one pattern:
> 
> ```
> f a = expr
> ```
> 
> will be desugered to:
> 
> ```
> f x = match x with
>     a -> expr
> ```

> - Top level function definition with no less than two patterns:
> 
> ```
> f (x1,x2) (y1,y2) = expr
> ```
> 
> will be desugered to:
> 
> ```
> f v1 v2 = match (v1, v2) with
>     ((x1,x2), (y1,y2))-> expr
> ```

~~Note: Should fail building until pull[#116](https://github.com/ssm-lang/sslang/pull/116) is merged~~