### PR TITLE
stop skipping of list and string desugaring

### DIFF
--- a/src/Front.hs
+++ b/src/Front.hs
@@ -79,12 +79,12 @@ parseAst opt src = do
   astP <- parseOperators ast
   when (optMode opt == DumpAstParsed) $ dump $ show $ pretty astP
 
-  astDS <- desugarStrings astP
-  astDL <- desugarLists astDS
+  astS <- desugarStrings astP
+  astL <- desugarLists astS
 
   -- TODO: other desugaring
-  Pattern.checkAnomaly astDL
-  astD <- Pattern.desugarProgram astP
+  Pattern.checkAnomaly astL
+  astD <- Pattern.desugarProgram astL
 
   when (optMode opt == DumpAstFinal) $ dump $ show $ pretty astD
   return astD

--- a/src/IR/LowerAst.hs
+++ b/src/IR/LowerAst.hs
@@ -186,7 +186,7 @@ lowerLit (A.LitInt i)   = return $ I.LitIntegral i
 lowerLit A.LitEvent     = return I.LitEvent
 lowerLit (A.LitChar _c) = Compiler.todo "Char literals are not yet implemented"
 lowerLit (A.LitString _s) =
-  Compiler.unexpected "lowerLit: LitStrings should have already been desugared:"
+  Compiler.unexpected "lowerLit: LitStrings should have already been desugared"
 lowerLit (A.LitRat _r) =
   Compiler.todo "Rational literals are not yet implemented"
 

--- a/src/IR/LowerAst.hs
+++ b/src/IR/LowerAst.hs
@@ -186,7 +186,7 @@ lowerLit (A.LitInt i)   = return $ I.LitIntegral i
 lowerLit A.LitEvent     = return I.LitEvent
 lowerLit (A.LitChar _c) = Compiler.todo "Char literals are not yet implemented"
 lowerLit (A.LitString _s) =
-  Compiler.todo "String literals are not yet implemented"
+  Compiler.unexpected "lowerLit: LitStrings should have already been desugared:"
 lowerLit (A.LitRat _r) =
   Compiler.todo "Rational literals are not yet implemented"
 


### PR DESCRIPTION
This PR fixes the threading compiler of passes over the program so that the results of desugarStrings and desguarLists are fed correctly into the next pass, Pattern.desugarProgram.