### PR TITLE
Add par stub

### DIFF
--- a/src/IR.hs
+++ b/src/IR.hs
@@ -1,34 +1,41 @@
--- | Intermediate representation (IR) stages of the compiler pipeline.
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+-- | Intermediate representation (IR) stages of the compiler pipeline.
 module IR where
 
-import           Common.Compiler
-import           Common.Default                 ( Default(..) )
-import qualified Front.Ast                     as A
-import qualified IR.IR                         as I
+import Common.Compiler
+import Common.Default (Default (..))
+import qualified Front.Ast as A
+import qualified IR.IR as I
 
-import           IR.ClassInstantiation          ( instProgram )
-import           IR.DConToFunc                  ( dConToFunc )
-import           IR.DesugarPattern              ( desugarPattern )
-import           IR.ExternToCall                ( externToCall )
-import           IR.InsertRefCounting           ( insertRefCounting )
-import           IR.LambdaLift                  ( liftProgramLambdas )
-import           IR.LowerAst                    ( lowerProgram )
-import           IR.SegmentLets                 ( segmentLets )
-import           IR.Types                       ( fromAnnotations
-                                                , typecheckProgram
-                                                )
-import           Control.Monad                  ( (>=>)
-                                                , when
-                                                )
-import           System.Console.GetOpt          ( ArgDescr(..)
-                                                , OptDescr(..)
-                                                )
-import           Text.Show.Pretty
+import Control.Monad (
+  when,
+  (>=>),
+ )
+import IR.ClassInstantiation (instProgram)
+import IR.DConToFunc (dConToFunc)
+import IR.DesugarPattern (desugarPattern)
+import IR.ExternToCall (externToCall)
+import IR.InsertRefCounting (insertRefCounting)
+import IR.LambdaLift (liftProgramLambdas)
+import IR.LowerAst (lowerProgram)
+import IR.OptimizePar (optimizePar)
+import IR.SegmentLets (segmentLets)
+import IR.Types (
+  fromAnnotations,
+  typecheckProgram,
+ )
+import System.Console.GetOpt (
+  ArgDescr (..),
+  OptDescr (..),
+ )
+import Text.Show.Pretty
 
--- | Operation modes for the IR compiler stage.
---
--- By default, 'Continue' completes the pipeline end-to-end.
+
+{- | Operation modes for the IR compiler stage.
+
+ By default, 'Continue' completes the pipeline end-to-end.
+-}
 data Mode
   = Continue
   | DumpIR
@@ -40,42 +47,53 @@ data Mode
   | DumpIRFinal
   deriving (Eq, Show)
 
+
 -- | Compiler options for the IR compiler stage.
-newtype Options = Options { mode :: Mode }
+newtype Options = Options {mode :: Mode}
   deriving (Eq, Show)
 
+
 instance Default Options where
-  def = Options { mode = Continue }
+  def = Options{mode = Continue}
+
 
 -- | CLI options for the IR compiler stage.
 options :: [OptDescr (Options -> Options)]
 options =
-  [ Option ""
-           ["dump-ir"]
-           (NoArg $ setMode DumpIR)
-           "Print the IR immediately after lowering"
-  , Option ""
-           ["dump-ir-annotated"]
-           (NoArg $ setMode DumpIRTyped)
-           "Print the fully-typed IR just before type inference"
-  , Option ""
-           ["dump-ir-typed"]
-           (NoArg $ setMode DumpIRTyped)
-           "Print the fully-typed IR after type inference"
-  , Option ""
-           ["dump-ir-typed-ugly"]
-           (NoArg $ setMode DumpIRTypedShow)
-           "Ugly-Print the fully-typed IR after type inference"
-  , Option ""
-           ["dump-ir-lifted"]
-           (NoArg $ setMode DumpIRLifted)
-           "Print the IR after lambda lifting"
-  , Option ""
-           ["dump-ir-final"]
-           (NoArg $ setMode DumpIRFinal)
-           "Print the last IR representation before code generation"
+  [ Option
+      ""
+      ["dump-ir"]
+      (NoArg $ setMode DumpIR)
+      "Print the IR immediately after lowering"
+  , Option
+      ""
+      ["dump-ir-annotated"]
+      (NoArg $ setMode DumpIRTyped)
+      "Print the fully-typed IR just before type inference"
+  , Option
+      ""
+      ["dump-ir-typed"]
+      (NoArg $ setMode DumpIRTyped)
+      "Print the fully-typed IR after type inference"
+  , Option
+      ""
+      ["dump-ir-typed-ugly"]
+      (NoArg $ setMode DumpIRTypedShow)
+      "Ugly-Print the fully-typed IR after type inference"
+  , Option
+      ""
+      ["dump-ir-lifted"]
+      (NoArg $ setMode DumpIRLifted)
+      "Print the IR after lambda lifting"
+  , Option
+      ""
+      ["dump-ir-final"]
+      (NoArg $ setMode DumpIRFinal)
+      "Print the last IR representation before code generation"
   ]
-  where setMode m o = o { mode = m }
+ where
+  setMode m o = o{mode = m}
+
 
 -- | Lower from AST to IR (with annotations).
 lower :: Options -> A.Program -> Pass (I.Program I.Annotations)
@@ -84,16 +102,19 @@ lower opt p = do
   when (mode opt == DumpIR) $ dump $ fmap fromAnnotations p
   return p
 
--- | Type inference + check against type annotations.
---
--- After this stage, no compiler errors should be thrown.
+
+{- | Type inference + check against type annotations.
+
+ After this stage, no compiler errors should be thrown.
+-}
 typecheck :: Options -> I.Program I.Annotations -> Pass (I.Program I.Type)
 typecheck opt p = do
   when (mode opt == DumpIRAnnotated) $ dump $ fmap fromAnnotations p
   p <- typecheckProgram p
   when (mode opt == DumpIRTyped) $ dump p
-  when (mode opt == DumpIRTypedShow) $ (throwError . Dump . ppShow ) p
+  when (mode opt == DumpIRTypedShow) $ (throwError . Dump . ppShow) p
   return p
+
 
 -- | IR transformations to prepare for codegen.
 transform :: Options -> I.Program I.Type -> Pass (I.Program I.Type)
@@ -103,11 +124,13 @@ transform opt p = do
   p <- segmentLets p
   p <- dConToFunc p
   p <- externToCall p
+  p <- optimizePar p
   p <- liftProgramLambdas p
   when (mode opt == DumpIRLifted) $ dump p
   p <- insertRefCounting p
   when (mode opt == DumpIRFinal) $ dump p
   return p
+
 
 -- | IR compiler stage.
 run :: Options -> A.Program -> Pass (I.Program I.Type)

--- a/src/IR/OptimizePar.hs
+++ b/src/IR/OptimizePar.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Remove unnecessary Par expressions from the IR
+
+This pass detects unnecessary par expressions and then replaces them with equivalent sequential expressions.
+-}
+module IR.OptimizePar (
+  optimizePar,
+) where
+
+import Common.Compiler
+import qualified Common.Compiler as Compiler
+import Control.Monad.State.Lazy (
+  MonadState,
+  StateT (..),
+  evalStateT,
+  gets,
+  modify,
+ )
+import IR.IR (Literal (LitIntegral))
+import qualified IR.IR as I
+
+
+-- | Optimization Environment
+data OptParCtx = OptParCtx
+  { -- | 'numPars' the number of par nodes in the input program's IR.
+    numPars :: Int
+  , -- | 'numLitInts' the number of "bad" par node in the input program's IR.
+    numBadPars :: Int
+  }
+
+
+-- | OptPar Monad
+newtype OptParFn a = LiftFn (StateT OptParCtx Compiler.Pass a)
+  deriving (Functor) via (StateT OptParCtx Compiler.Pass)
+  deriving (Applicative) via (StateT OptParCtx Compiler.Pass)
+  deriving (Monad) via (StateT OptParCtx Compiler.Pass)
+  deriving (MonadFail) via (StateT OptParCtx Compiler.Pass)
+  deriving (MonadError Compiler.Error) via (StateT OptParCtx Compiler.Pass)
+  deriving (MonadState OptParCtx) via (StateT OptParCtx Compiler.Pass)
+
+
+-- | Example func to delete later! Demonstrates how to extract a value from the OptParFn Monad
+getNumberOfPars :: OptParFn Int
+getNumberOfPars = gets numPars
+
+
+-- | Example func to delete later! Demonstrates how to modify a value in the OptParFn Monad
+updateNumberOfPars :: Int -> OptParFn ()
+updateNumberOfPars num = do
+  modify $ \st -> st{numPars = num}
+
+
+-- | Run a LiftFn computation.
+runLiftFn :: OptParFn a -> Compiler.Pass a
+runLiftFn (LiftFn m) =
+  evalStateT
+    m
+    OptParCtx
+      { numPars = 0
+      , numBadPars = 0
+      }
+
+
+{- | Entry-point to Par Optimization.
+
+Maps over top level definitions, removing unnecessary pars.
+-}
+optimizePar :: I.Program I.Type -> Compiler.Pass (I.Program I.Type)
+optimizePar p = runLiftFn $ do
+  optimizedDefs <- mapM optimizeParTop $ I.programDefs p
+  return $ p{I.programDefs = optimizedDefs}
+
+
+-- | Given a top-level definition, detect + replace unnecessary par expressions
+optimizeParTop :: (I.VarId, I.Expr I.Type) -> OptParFn (I.VarId, I.Expr I.Type)
+optimizeParTop (nm, rhs) = do
+  rhs' <- detectReplaceBadPar rhs
+  (rhs'', _) <- countPars rhs' -- calling this so we don't get an "unused" warning
+  (rhs''', _) <- countBadPars rhs'' -- calling this so we don't get an "unused" warning
+  -- uncomment the line below to test countPars
+  -- (_, result) <- countPars rhs
+  -- _ <- fail (show nm ++ ": Number of Par Exprs: " ++ show result)
+  -- uncomment the two lines below to test countBadPars
+  -- (_, result') <- countBadPars rhs
+  -- _ <- fail (show nm ++ ": Number of Bad Par Exprs: " ++ show result')
+  return (nm, rhs''')
+
+
+-- | Detect Unnecessary Par Expressions + Replace With Equivalent Sequential Expression
+detectReplaceBadPar :: I.Expr I.Type -> OptParFn (I.Expr I.Type)
+detectReplaceBadPar e = do
+  pure e -- for now, just return the same thing (don't do anyting)
+
+
+{- | 1) Count Par Nodes
+
+Practice Exercise to Delete Later!
+
+Traverse the IR representation of the body of a top level defintion,
+and count the number of par expressions present.
+Return the body unchanged, as well as the count numPars.
+-}
+countPars :: I.Expr I.Type -> OptParFn (I.Expr I.Type, Int)
+countPars e = do
+  -- currently a stub
+  -- PUT YOUR IMPLEMENTATION HERE
+  x <- getNumberOfPars
+  updateNumberOfPars (x + 0) -- calling this so we don't get an "unused" warning
+  return (e, x)
+
+
+{- | 1.5) Implement IsBad Predicate
+
+Suggested by John during Monday Meeting.
+Returns true if par expr contains only instantaneous expressions as arguments.
+False otherwise.
+Useful for exercise 2.
+-}
+isBad :: I.Expr I.Type -> Bool
+isBad _ = False -- currently a stub
+
+
+{- | 2) Count Bad Par Nodes
+
+Practice Exercise to Delete Later!
+
+Traverse the IR representation of the body of a top level defintion,
+and count the number of BAD par expressions present.
+Use the helper predicate "isBad" in your implementation.
+Return the body unchanged, as well as the count numBadPars.
+-}
+countBadPars :: I.Expr I.Type -> OptParFn (I.Expr I.Type, Int)
+countBadPars e = do
+  -- currently a stub
+  let y = isBad (I.Lit (LitIntegral 5) (I.extract e)) -- calling this so we don't get an "unused" warning
+  return (e, fromEnum y)


### PR DESCRIPTION
Adds a stubbed-out pass over the IR for optimizing par called optimizePar.hs.
Matthew will edit this file (in a feature branch) in the future.
Currently, the pass doesn't do anything, so it's safe to push to main.