### PR TITLE
Fix pretty printing of arguments

### DIFF
--- a/src/IR/Pretty.hs
+++ b/src/IR/Pretty.hs
@@ -100,12 +100,12 @@ instance Pretty (Program Type) where
 prettyDef :: (Binder Type, Expr Type) -> Doc ann
 prettyDef (v, unfoldLambda -> ([], b)) = prettyBinderTyped False v <+> "=" <> hardBlock (pretty b)
 prettyDef (v, unfoldLambda -> (as, b)) =
-  let args = sep $ map (prettyBinderTyped True) as
+  let args = layoutBlock' $ vsep $ map (prettyBinderTyped True) as
       t = extract v
       typeInfo
         | hasTypeInfo t = ":" <+> pretty t
         | otherwise = ""
-   in prettyBinderUntyped v <+> args <> typeInfo <+> "=" <> hardBlock (pretty b)
+   in prettyBinderUntyped v <> args <> typeInfo <+> "=" <> hardBlock (pretty b)
 
 
 instance Pretty (Expr Type) where

--- a/src/IR/Pretty.hs
+++ b/src/IR/Pretty.hs
@@ -30,7 +30,7 @@ layoutBlock' :: Doc ann -> Doc ann
 layoutBlock' d = group $ flatAlt indented oneLiner
  where
   oneLiner = " " <> d
-  indented = line <> indents d
+  indented = line <> indents (indents d)
 
 
 layoutBlock :: Doc ann -> Doc ann


### PR DESCRIPTION
Before:

```
puts_ (putc: (Int32 -> 'ir_t35))
(s: String): ((Int32 -> 'ir_t35) -> (String -> ())) =
  let puts__: (String -> ()) = puts__puts__ putc
  puts__ s
```

After:

```
puts_
  (putc: (Int32 -> 'ir_t35))
  (s: String): ((Int32 -> 'ir_t35) -> (String -> ())) =
  let puts__: (String -> ()) = puts__puts__ putc
  puts__ s
```

It is fix