### PR TITLE
Add preliminary support for now and last

### DIFF
--- a/src/Codegen/Codegen.hs
+++ b/src/Codegen/Codegen.hs
@@ -829,9 +829,13 @@ genPrim I.Loop [b] _ = do
   (_, bodyStms) <- genExpr b
   return (unit, [citems|for (;;) { $items:bodyStms }|])
 genPrim I.Break [] _ = return (undef, [citems|break;|])
-genPrim I.Now [_] t = do
+genPrim I.Now [] t = do
   tmp <- genTmp t
-  return (tmp, [citems|$exp:tmp = $exp:(marshal $ ccall now []);|])
+  return (tmp, [citems|$exp:tmp = $exp:(new_time $ ccall now []);|])
+genPrim I.Last [r] t = do
+  (r', stms) <- genExpr r
+  tmp <- genTmp t
+  return (tmp, stms ++ [citems|$exp:tmp = $exp:(new_time $ sv_last_updated r');|])
 genPrim (I.CQuote e) [] _ = return ([cexp|$exp:(EscExp e)|], [])
 genPrim (I.CCall s) es _ = do
   (argExps, argStms) <- second concat . unzip <$> mapM genExpr es

--- a/src/Codegen/LibSSM.hs
+++ b/src/Codegen/LibSSM.hs
@@ -213,6 +213,11 @@ read_time :: C.Exp -> C.Exp
 read_time to = [cexp|ssm_time_read($exp:to)|]
 
 
+-- | Read the @last_updated@ field of an 'ssm_value_t' pointing to a scheduled variable.
+sv_last_updated :: C.Exp -> C.Exp
+sv_last_updated sv = [cexp|$exp:(to_sv sv)->last_updated|]
+
+
 -- | @ssm_priority_t@, thread priority.
 priority_t :: C.Type
 priority_t = [cty|typename ssm_priority_t|]
@@ -401,8 +406,8 @@ closure_apply f a act prio depth ret =
 
 
 -- | @ssm_closure_apply@, apply a closure to an argument, consuming the closure.
-closure_apply_final
-  :: C.Exp -> C.Exp -> C.Exp -> C.Exp -> C.Exp -> C.Exp -> C.Exp
+closure_apply_final ::
+  C.Exp -> C.Exp -> C.Exp -> C.Exp -> C.Exp -> C.Exp -> C.Exp
 closure_apply_final f a act prio depth ret =
   [cexp|ssm_closure_apply_final($exp:f, $exp:a, $exp:act, $exp:prio, $exp:depth, $exp:ret)|]
 

--- a/src/Front/Ast.hs
+++ b/src/Front/Ast.hs
@@ -99,6 +99,8 @@ data Expr
   | CCall Identifier [Expr]
   | Tuple [Expr]
   | ListExpr [Expr]
+  | Last Expr
+  | Now
   deriving (Eq, Show, Typeable, Data)
 
 {- | An operator region: a flat list of alternating expressions and operators
@@ -294,6 +296,8 @@ instance Pretty Expr where
    where
     prettyPatExprTup (p, e) = pretty p <+> pretty "=" <+> braces (pretty e)
   pretty (ListExpr es) = brackets $ hsep $ punctuate comma $ map pretty es
+  pretty Now           = pretty "now"
+  pretty (Last e)      = pretty "@@" <+> pretty e
   pretty NoExpr        = error "Unexpected NoExpr"
 
 instance Pretty Literal where

--- a/src/Front/Identifiers.hs
+++ b/src/Front/Identifiers.hs
@@ -62,7 +62,6 @@ builtinData =
       , ">"
       , "deref"
       , "new"
-      , "now"
       ]
  where
   mkBuiltin i = (i, DataInfo{dataKind = Builtin})

--- a/src/Front/Parser.y
+++ b/src/Front/Parser.y
@@ -41,6 +41,7 @@ import Data.Bifunctor (first)
   'fun'     { Token (_, TFun) }
   'match'   { Token (_, TMatch) }
   'extern'  { Token (_, TExtern) }
+  'now'     { Token (_, TNow) }
   '='       { Token (_, TEq) }
   '<-'      { Token (_, TLarrow) }
   '->'      { Token (_, TRarrow) }
@@ -51,6 +52,7 @@ import Data.Bifunctor (first)
   ';'       { Token (_, TSemicolon) }
   ','       { Token (_, TComma) }
   '_'       { Token (_, TUnderscore) }
+  '@@'      { Token (_, TAtAt) }
   '@'       { Token (_, TAt) }
   '&'       { Token (_, TAmpersand) }
   '('       { Token (_, TLparen) }
@@ -304,6 +306,7 @@ exprElse                              --> Expr
 -- | Expressions with application by juxtaposition.
 exprApp                               --> Expr
   : exprApp exprAtom                    { Apply $1 $2 }
+  | '@@' exprAtom                       { Last $2 }
   | exprAtom                            { $1 }
 
 -- | Atomic expressions.
@@ -312,6 +315,7 @@ exprAtom
   | string                              { Lit (LitString $1) }
   | cquote                              { CQuote $1 }
   | id                                  { Id $1 }
+  | 'now'                               { Now }
   | '(' expr ')'                        { $2 }
   | '(' ')'                             { Lit LitEvent }
   | '[' exprList ']'                    { ListExpr $2 }

--- a/src/Front/Scanner.x
+++ b/src/Front/Scanner.x
@@ -158,6 +158,7 @@ tokens :-
     -- Keywords that just do as they be.
     extern              { keyword TExtern }
     after               { keyword TAfter }
+    now                 { keyword TNow }
     \:                  { keyword TColon }
     \|\|                { keyword TDBar }
     \-\>                { keyword TRarrow }
@@ -166,6 +167,7 @@ tokens :-
     \:                  { keyword TColon }
     \,                  { keyword TComma }
     \_                  { keyword TUnderscore }
+    \@\@                { keyword TAtAt }
     \@                  { keyword TAt }
     \&                  { keyword TAmpersand }
 

--- a/src/Front/Scope.hs
+++ b/src/Front/Scope.hs
@@ -367,6 +367,8 @@ scopeExpr (A.OpRegion e o) =
         <> fromString (show o)
 scopeExpr (A.CQuote _) = return ()
 scopeExpr (A.CCall _ es) = mapM_ scopeExpr es
+scopeExpr (A.Last e) = scopeExpr e
+scopeExpr A.Now = return ()
 scopeExpr A.NoExpr = return ()
 
 

--- a/src/Front/Token.hs
+++ b/src/Front/Token.hs
@@ -38,6 +38,8 @@ data TokenType
   | TPar
   | TLoop
   | TLet
+  | TNow
+  | TAtAt
   | TMatch
   | TAfter
   | TWait
@@ -104,6 +106,8 @@ instance Pretty TokenType where
   pretty TPar = pretty "par"
   pretty TLoop = pretty "loop"
   pretty TLet = pretty "let"
+  pretty TNow = pretty "now"
+  pretty TAtAt = pretty "@@"
   pretty TMatch = pretty "match"
   pretty TAfter = pretty "after"
   pretty TWait = pretty "wait"

--- a/src/IR/Constraint/Constrain/Expression.hs
+++ b/src/IR/Constraint/Constrain/Expression.hs
@@ -190,7 +190,8 @@ lookupPrim len prim = do
     I.Assign -> return $ Can.Ref (Can.TVar "a") --> Can.TVar "a" --> Can.Unit
     I.After ->
       return $ Can.I32 --> Can.Ref (Can.TVar "a") --> Can.TVar "a" --> Can.Unit
-    I.Now -> return $ Can.Unit --> Can.I32
+    I.Now -> return Can.I64
+    I.Last -> return $ Can.Ref (Can.TVar "a") --> Can.I64
     I.CQuote _ -> return $ Can.TVar "a"
     I.Loop -> return $ Can.TVar "a" --> Can.Unit
     I.Break -> return Can.Unit

--- a/src/IR/IR.hs
+++ b/src/IR/IR.hs
@@ -230,6 +230,8 @@ data Primitive
     Break
   | -- | @Now@ obtains the value of the current instant
     Now
+  | -- | @Last@ obtains the time a value was last assigned
+    Last
   | -- | Inlined C expression code.
     PrimOp PrimOp
   | -- | Primitive operator.

--- a/src/IR/LowerAst.hs
+++ b/src/IR/LowerAst.hs
@@ -249,6 +249,10 @@ lowerExpr (A.Tuple es) =
  where
   apply_recurse e [] = e
   apply_recurse e (x : xs) = apply_recurse (I.App e x untyped) xs
+lowerExpr (A.Last e) = do
+  e' <- lowerExpr e
+  return $ I.Prim I.Last [e'] untyped
+lowerExpr A.Now = return $ I.Prim I.Now [] untyped
 lowerExpr (A.ListExpr _) =
   Compiler.unexpected "lowerExpr: ListExprs should have already been desugared"
 


### PR DESCRIPTION
Doing so in the hackiest possible way...

Super quirks:

- `now` has type `Int64`, but it is code-genned into `ssm_now()`. This means that even though it _looks_ like a variable, it does not behave like one, in that its value depends on the instant in which you evaluate it.

- `@@ r` is our syntax for `last r`.

- Both of these primitives return `Int64`, which is not really a type we've used or tested at all. Right now I use `ssm_new_time()` to allocate them onto the heap (so that we still get an `ssm_value_t` handle to them, but sslang doesn't actually provide any way to read them directly. We'll use the cquote stuff to hack in some primitives, but until we have type classes/proper operator overloading, using `==` and `<` etc. on times just won't typecheck.

But damnit I need these primitives, so Landin forgive me I will merge this without review. 